### PR TITLE
Setup Routing

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,3 +1,3 @@
 export default function AdminPage() {
   return <div>Admin Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,3 +1,3 @@
 export default function DashboardPage() {
   return <div>Dashboard Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/feedback/[id]/page.tsx
+++ b/frontend/src/app/feedback/[id]/page.tsx
@@ -1,3 +1,3 @@
 export default function FeedbackDetailPage() {
   return <div>Feedback Detail Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -1,3 +1,3 @@
 export default function HistoryPage() {
   return <div>History Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+  return <div>Login / Auth Page (placeholder)</div>;
+}

--- a/frontend/src/app/new-training/page.tsx
+++ b/frontend/src/app/new-training/page.tsx
@@ -1,3 +1,3 @@
 export default function NewTrainingPage() {
   return <div>New Training Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,3 +1,3 @@
 export default function OnboardingPage() {
   return <div>Onboarding Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function HomePage() {
-  return <div>Login / Auth Page (placeholder)</div>;
+  return <div>About Page (placeholder)</div>;
 }

--- a/frontend/src/app/preperation/[id]/page.tsx
+++ b/frontend/src/app/preperation/[id]/page.tsx
@@ -1,3 +1,3 @@
 export default function PreparationPage() {
   return <div>Preparation Page (placeholder)</div>;
-} 
+}

--- a/frontend/src/app/simulation/[id]/page.tsx
+++ b/frontend/src/app/simulation/[id]/page.tsx
@@ -1,3 +1,3 @@
 export default function SimulationPage() {
   return <div>Simulation Page (placeholder)</div>;
-} 
+}


### PR DESCRIPTION
# Setup Routing
### Current Situation

Missing routes for main pages. Only one route ("/") displaying a messaging UI

### Proposed Solution

Added scaffolding for the main routes, with empty placeholder pages, corresponding to the figma wireframes and mockups. 

#### Implications

Removed the message UI where users could post messages and view their last messages.

### Testing

Manual testing, everything works as intended.

### Reviewer Notes
Incase the previous messaging UI should remain, then it can be reverted from the main route in app/page.tsx (currently the Login/Auth page)
