### PR TITLE
fix(translation): remove url prefix for default locale

### DIFF
--- a/frontend/src/i18n/routing.ts
+++ b/frontend/src/i18n/routing.ts
@@ -3,6 +3,7 @@ import { defineRouting } from 'next-intl/routing';
 const routing = defineRouting({
   locales: ['en', 'de'],
   defaultLocale: 'en',
+  localePrefix: 'as-needed',
 });
 
 export default routing;


### PR DESCRIPTION
# Fix Lang Prefix
### Current Situation
Pages are only accessible under /lang/pagename. For default locale, it should be accessible under /pagename as well.
### Proposed Solution
Remove locale prefix if default locale. 
#### Implications
None
### Testing
Pages should be now accessible with normal url. Using /en/page should also redirect to /pagename
### Reviewer Notes
None