### PR TITLE
fix(M): Fix deployment job order

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,7 +33,7 @@ jobs:
 
   build:
     name: Build
-    needs: [ lint, test ]
+    needs: [ test ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -44,9 +44,9 @@ jobs:
         run: npm run build
         working-directory: ./frontend
 
-  deploy-production:
+  deploy:
     name: Deploy (Production)
-    needs: [ lint, build ]
+    needs: [ build ]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Pipeline before this change: https://github.com/jst-seminar-rostlab-tum/personio-foundation-coachai/actions/runs/15159971155
After these changes are applied, the order should be lint->test->build->deploy