### PR TITLE
Feat: add endpoint to retrieve specific training session feedback 

### DIFF
--- a/backend/routers/training_session_feedback_route.py
+++ b/backend/routers/training_session_feedback_route.py
@@ -7,6 +7,7 @@ from sqlmodel import Session, select
 from ..database import get_session
 from ..models.training_session import TrainingSession
 from ..models.training_session_feedback import (
+    FeedbackStatusEnum,
     TrainingSessionFeedback,
     TrainingSessionFeedbackCreate,
     TrainingSessionFeedbackRead,
@@ -17,7 +18,7 @@ router = APIRouter(prefix='/training-session-feedback', tags=['Training Session 
 
 @router.get('/', response_model=list[TrainingSessionFeedbackRead])
 def get_training_session_feedbacks(
-    session: Annotated[Session, Depends(get_session)],
+        session: Annotated[Session, Depends(get_session)],
 ) -> list[TrainingSessionFeedback]:
     """
     Retrieve all training session feedbacks.
@@ -29,7 +30,7 @@ def get_training_session_feedbacks(
 
 @router.post('/', response_model=TrainingSessionFeedbackRead)
 def create_training_session_feedback(
-    feedback: TrainingSessionFeedbackCreate, session: Annotated[Session, Depends(get_session)]
+        feedback: TrainingSessionFeedbackCreate, session: Annotated[Session, Depends(get_session)]
 ) -> TrainingSessionFeedback:
     """
     Create a new training session feedback.
@@ -46,11 +47,32 @@ def create_training_session_feedback(
     return db_feedback
 
 
+@router.get('/{feedback_id}', response_model=TrainingSessionFeedbackRead)
+def get_training_session_feedback(
+        feedback_id: UUID, session: Annotated[Session, Depends(get_session)]
+) -> TrainingSessionFeedbackRead:
+    """
+    Retrieve a specific training feedback by ID.
+    """
+    feedback = session.get(TrainingSessionFeedback, feedback_id)
+
+    if not feedback:
+        raise HTTPException(status_code=404, detail='Session feedback not found')
+
+    if feedback.status == FeedbackStatusEnum.pending:
+        raise HTTPException(status_code=202, detail='Session feedback in progress.')
+
+    elif feedback.status == FeedbackStatusEnum.failed:
+        raise HTTPException(status_code=500, detail='Session feedback failed.')
+
+    return feedback
+
+
 @router.put('/{feedback_id}', response_model=TrainingSessionFeedbackRead)
 def update_training_session_feedback(
-    feedback_id: UUID,
-    updated_data: dict,
-    session: Annotated[Session, Depends(get_session)],
+        feedback_id: UUID,
+        updated_data: dict,
+        session: Annotated[Session, Depends(get_session)],
 ) -> TrainingSessionFeedback:
     """
     Update an existing training session feedback.
@@ -74,7 +96,7 @@ def update_training_session_feedback(
 
 @router.delete('/{feedback_id}', response_model=dict)
 def delete_training_session_feedback(
-    feedback_id: UUID, session: Annotated[Session, Depends(get_session)]
+        feedback_id: UUID, session: Annotated[Session, Depends(get_session)]
 ) -> dict:
     """
     Delete a training session feedback.


### PR DESCRIPTION
Closed #153 
This pull request introduces a new endpoint to retrieve training session feedback by ID and adds a supporting enum for feedback status. The changes enhance the functionality of the `training_session_feedback_route` by enabling detailed feedback retrieval and handling different feedback statuses.

### New functionality for feedback retrieval:

* [`backend/routers/training_session_feedback_route.py`](diffhunk://#diff-3563d164aa18206ddac40c733ac5b3a02b598d90190ce8ee93c7a66870dd9f3fR50-R70): Added a new `GET` endpoint (`get_training_session_feedback`) to retrieve specific training session feedback by ID. This endpoint handles various feedback statuses (`pending`, `failed`) with appropriate HTTP responses.

### Supporting changes:

* [`backend/routers/training_session_feedback_route.py`](diffhunk://#diff-3563d164aa18206ddac40c733ac5b3a02b598d90190ce8ee93c7a66870dd9f3fR10): Imported `FeedbackStatusEnum` to support status checks in the new endpoint.