### PR TITLE
Enable Manual Selection of PR Templates via Preview Tab

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/config.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/config.yml
@@ -1,7 +1,0 @@
-# .github/PULL_REQUEST_TEMPLATE/config.yml
-blank_issues_enabled: false
-templates:
-  - name: Backend PR Template
-    path: backend.md
-  - name: Default PR Template
-    path: default.md

--- a/.github/PULL_REQUEST_TEMPLATE/config.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# .github/PULL_REQUEST_TEMPLATE/config.yml
+blank_issues_enabled: false
+templates:
+  - name: Backend PR Template
+    path: backend.md
+  - name: Default PR Template
+    path: default.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+Got to **Preview** Tab ^^^ select your template:
+
+- [Backend PR Template](?template=backend.md)
+- [Default PR Template](?template=default.md)


### PR DESCRIPTION
I initially added multiple pull request templates under .github/PULL_REQUEST_TEMPLATE/, expecting GitHub to automatically present them as selectable options in the UI. However, GitHub does not support multiple PR templates with a dropdown menu.

GitHub only loads a PR template automatically if it is named .github/pull_request_template.md. When multiple templates exist, developers are expected to manually modify the PR URL using a ?template=your_template.md query parameter—which is not practical.

To address this, I’ve created a default pull_request_template.md that includes a short instruction and links to the specific templates. When creating a new pull request, please switch to the Preview tab and click the appropriate link to load the correct template.

This workaround provides a more usable way to select the right template without needing to edit URLs manually.

Let me know if you’d like changes to the wording or format.