### PR TITLE
feat(F-272): integrate with get paginated sessions endpoint

### DIFF
--- a/frontend/src/app/[locale]/(main)/history/components/PreviousSessions.tsx
+++ b/frontend/src/app/[locale]/(main)/history/components/PreviousSessions.tsx
@@ -2,106 +2,96 @@
 
 import { ChevronDown, Download, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-
-const mockSessions = [
-  {
-    title: 'Negotiating Job Offers',
-    description: 'Practice salary negotiation with a potential candidate',
-    date: '16.04.25',
-    time: '12:37',
-  },
-  {
-    title: 'Conflict Resolution',
-    description: 'Mediate a disagreement between team members',
-    date: '08.04.25',
-    time: '13:36',
-  },
-  {
-    title: 'Performance Review',
-    description: 'Conduct a quaterly performance review',
-    date: '16.04.25',
-    time: '12:37',
-  },
-  {
-    title: 'Team Building',
-    description: 'Facilitate a team building exercise',
-    date: '07.03.25',
-    time: '10:15',
-  },
-  {
-    title: 'Feedback Session',
-    description: 'Give constructive feedback to a peer',
-    date: '22.02.25',
-    time: '09:00',
-  },
-  {
-    title: 'Project Kickoff',
-    description: 'Start a new project with the team',
-    date: '15.01.25',
-    time: '14:20',
-  },
-  {
-    title: 'One-on-One',
-    description: 'Have a one-on-one meeting with a direct report',
-    date: '10.01.25',
-    time: '11:45',
-  },
-  {
-    title: 'Strategy Planning',
-    description: 'Plan the strategy for the next quarter',
-    date: '05.01.25',
-    time: '16:00',
-  },
-];
+import { getPaginatedSessions } from '@/services/SessionService';
+import { Session } from '@/interfaces/Session';
 
 export default function PreviousSessions() {
-  const [visibleCount, setVisibleCount] = useState(3);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [loading, setLoading] = useState(false);
   const t = useTranslations('History');
 
-  const visibleSessions = mockSessions.slice(0, visibleCount);
-  const canLoadMore = visibleCount < mockSessions.length;
+  const PAGE_SIZE = 5;
+
+  // TODO: remove this once we have a proper auth system
+  const userId = 'bcfab91c-52d0-46e0-b132-13201dddaa1a';
+
+  // Format ISO date string to dd.MM.yy and time hh:mm
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: '2-digit' });
+  };
+  const formatTime = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+  };
+
+  const fetchSessions = async (pageNum: number) => {
+    setLoading(true);
+    try {
+      const data = await getPaginatedSessions(userId, pageNum, PAGE_SIZE);
+      setSessions((prev) => [...prev, ...data.sessions]);
+      setTotalPages(data.totalPages);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    // load first page
+    fetchSessions(1);
+  }, []);
 
   const handleLoadMore = () => {
-    setVisibleCount((prev) => Math.min(prev + 3, mockSessions.length));
+    if (page < totalPages && !loading) {
+      const next = page + 1;
+      setPage(next);
+      fetchSessions(next);
+    }
   };
+
+  const canLoadMore = page < totalPages;
 
   return (
     <div className="w-full mx-auto mt-10 px-4">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-2 gap-2 md:gap-0">
         <div className="text-xl">{t('previousSessions')}</div>
         <div className="flex justify-between md:gap-6">
-          <Button variant="ghost">
+          <Button variant="ghost" disabled={sessions.length === 0 || loading}>
             {t('exportHistory')} <Download />
           </Button>
-          <Button variant="ghost" className="hover:text-flame-50">
+          <Button variant="ghost" className="hover:text-flame-50" disabled={sessions.length === 0}>
             {t('clearAll')} <Trash2 />
           </Button>
         </div>
       </div>
       <div className="flex flex-col gap-4">
-        {visibleSessions.map((session, idx) => (
+        {sessions.map((session) => (
           <div
-            key={idx}
-            className=" border border-bw-20 rounded-xl px-4 py-3 flex justify-between items-center"
+            key={session.sessionId}
+            className="border border-bw-20 rounded-xl px-4 py-3 flex justify-between items-center"
           >
             <div>
               <div className="font-semibold text-bw-70 text-sm mb-1">{session.title}</div>
-              <div className="text-xs text-bw-40 leading-tight">{session.description}</div>
+              <div className="text-xs text-bw-40 leading-tight">{session.summary}</div>
             </div>
             <div className="text-xs text-bw-70 text-center whitespace-nowrap ml-4">
-              {session.date}
+              {formatDate(session.date)}
               <br />
-              {session.time}
+              {formatTime(session.date)}
             </div>
           </div>
         ))}
       </div>
       {canLoadMore && (
         <div className="flex justify-center mt-4">
-          <Button variant="ghost" onClick={handleLoadMore}>
-            {t('loadMore')} <ChevronDown />
+          <Button variant="ghost" onClick={handleLoadMore} disabled={loading}>
+            {loading ? t('loading') : t('loadMore')} <ChevronDown />
           </Button>
         </div>
       )}

--- a/frontend/src/interfaces/Session.ts
+++ b/frontend/src/interfaces/Session.ts
@@ -1,0 +1,21 @@
+export interface Session {
+  id: string;
+  title: string;
+  summary: string;
+  date: string;
+  score: number;
+  skills: {
+    structure: number;
+    empathy: number;
+    solutionFocus: number;
+    clarity: number;
+  };
+}
+
+export interface PaginatedSessionsResponse {
+  page: number;
+  limit: number;
+  totalPages: number;
+  totalSessions: number;
+  sessions: Session[];
+}

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -34,6 +34,8 @@ api.interceptors.response.use(
   }
 );
 
+export default api;
+
 /* export const userProfileApi = {
   create: async (data: UserProfileCreate) => {
     const response = await api.post('/user-profiles/', data);

--- a/frontend/src/services/SessionService.ts
+++ b/frontend/src/services/SessionService.ts
@@ -1,0 +1,23 @@
+import { PaginatedSessionsResponse } from '@/interfaces/Session';
+import api from './Api';
+
+export const getPaginatedSessions = async (
+  userId: string,
+  page: number,
+  pageSize: number
+): Promise<PaginatedSessionsResponse> => {
+  const response = await api.get<PaginatedSessionsResponse>(`/session`, {
+    params: {
+      page,
+      page_size: pageSize,
+    },
+    headers: {
+      'x-user-id': userId,
+    },
+  });
+  if (response.status === 200) {
+    return response.data;
+  }
+  console.error(response);
+  throw new Error('Failed to fetch sessions');
+};


### PR DESCRIPTION
# Integrate with get paginated sessions endpoint
### Current Situation
Mock sessions were used in the history page (PreviousSessions.tsx)
### Proposed Solution
Integrate with the get sessions endpoint through the SessionService
#### Implications
Potential minor merge conflicts with #293 
### Testing
Manual testing
### Reviewer Notes