### PR TITLE
feat(F-001): Add smooth scroll to #how-it-works in homepage 

### DIFF
--- a/frontend/src/app/[locale]/(about)/components/AboutPage.tsx
+++ b/frontend/src/app/[locale]/(about)/components/AboutPage.tsx
@@ -54,7 +54,7 @@ export default function AboutPageComponent() {
           </div>
         </section>
 
-        <section id="how-it-works" className="py-8 md:py-20 bg-white">
+        <section id="how-it-works" className="scroll-mt-20 py-8 md:py-20 bg-white">
           <div className="container">
             <div className="text-center max-w-3xl mx-auto mb-16">
               <h2 className="text-2xl md:text-3xl font-bold text-black mb-4">

--- a/frontend/src/app/[locale]/(about)/components/AboutPage.tsx
+++ b/frontend/src/app/[locale]/(about)/components/AboutPage.tsx
@@ -54,7 +54,7 @@ export default function AboutPageComponent() {
           </div>
         </section>
 
-        <section id="how-it-works" className="scroll-mt-20 py-8 md:py-20 bg-white">
+        <section id="how-it-works" className="scroll-mt-10 py-8 md:py-20 bg-white">
           <div className="container">
             <div className="text-center max-w-3xl mx-auto mb-16">
               <h2 className="text-2xl md:text-3xl font-bold text-black mb-4">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -101,3 +101,7 @@ body {
   font-weight: 400;
   letter-spacing: 0.01em;
 }
+
+html {
+  scroll-behavior: smooth;
+}


### PR DESCRIPTION
# Add smooth scroll to #how-it-works in homepage  instead of jumping
### Current Situation
Smooth scroll to #how-it-works in homepage was missing and the page jumped on click over the button.
### Proposed Solution
Added smooth scroll to globals.css .
#### Implications
Smooth scrolling is enabled.
### Testing
Manual testing on the Home Page.
### Reviewer Notes
Check if anything else needs to be added, etc. .
