### PR TITLE
Fix vector db tests failing when api key is missing

### DIFF
--- a/backend/app/connections/gemini_client.py
+++ b/backend/app/connections/gemini_client.py
@@ -8,10 +8,28 @@ from app.config import Settings
 settings = Settings()
 
 DEFAULT_MODEL = 'gemini-2.0-flash'
-gemini_client = genai.Client(api_key=settings.GEMINI_API_KEY)
+GEMINI_API_KEY = settings.GEMINI_API_KEY
+
+
+def _is_valid_api_key(key: str | None) -> bool:
+    return bool(key and isinstance(key, str) and key.strip())
+
+
+if not _is_valid_api_key(GEMINI_API_KEY):
+    print(
+        '[WARNING] GEMINI_API_KEY is missing or invalid. '
+        'AI features will be disabled and mock responses will be used.'
+    )
+    ENABLE_AI = False
+    gemini_client = None
+else:
+    ENABLE_AI = settings.ENABLE_AI
+    gemini_client = genai.Client(api_key=settings.GEMINI_API_KEY)
 
 
 def generate_gemini_content(contents: [Any], model: str = DEFAULT_MODEL) -> str:
+    if not ENABLE_AI or gemini_client is None:
+        return ''
     try:
         response = gemini_client.models.generate_content(model=model, contents=contents)
         return response.text
@@ -20,6 +38,8 @@ def generate_gemini_content(contents: [Any], model: str = DEFAULT_MODEL) -> str:
 
 
 def upload_audio_gemini(audio_path: str) -> File:
+    if not ENABLE_AI or gemini_client is None:
+        print('Cannot upload files to Gemini, AI is disabled')
     try:
         return gemini_client.files.upload(file=audio_path)
     except Exception as e:

--- a/backend/app/connections/gemini_client.py
+++ b/backend/app/connections/gemini_client.py
@@ -29,6 +29,10 @@ else:
 
 def generate_gemini_content(contents: [Any], model: str = DEFAULT_MODEL) -> str:
     if not ENABLE_AI or gemini_client is None:
+        print('Cannot upload files to Gemini, AI is disabled')
+        return ''
+    if None in contents:
+        print('None found in Gemini contents')
         return ''
     try:
         response = gemini_client.models.generate_content(model=model, contents=contents)


### PR DESCRIPTION
### Current Situation
Tests fail when GEMINI_API_KEY is missing
### Proposed Solution
Update Gemini client in app/connections to handle a missing api key
### Testing
Ran `tests/services/test_vector_db_context_service.py` and pre-commit hook locally with and without the api key