### PR TITLE
feat(B-252): add auth to GET admin stats, GET user stats, POST / GET review, GET session by id 

### DIFF
--- a/backend/app/routers/admin_dashboard_stats_route.py
+++ b/backend/app/routers/admin_dashboard_stats_route.py
@@ -5,6 +5,7 @@ from sqlmodel import Session as DBSession
 from sqlmodel import func, select
 
 from app.database import get_db_session
+from app.dependencies import require_admin
 from app.models.admin_dashboard_stats import AdminDashboardStats, AdminDashboardStatsRead
 from app.models.app_config import AppConfig
 from app.models.review import Review
@@ -13,7 +14,11 @@ from app.models.user_profile import UserProfile
 router = APIRouter(prefix='/admin-stats', tags=['Admin Dashboard'])
 
 
-@router.get('/', response_model=AdminDashboardStatsRead)
+@router.get(
+    '/',
+    response_model=AdminDashboardStatsRead,
+    dependencies=[Depends(require_admin)],
+)
 def get_admin_dashboard_stats(
     db_session: Annotated[DBSession, Depends(get_db_session)],
 ) -> AdminDashboardStatsRead:

--- a/backend/app/routers/review_route.py
+++ b/backend/app/routers/review_route.py
@@ -5,6 +5,7 @@ from sqlmodel import Session as DBSession
 from sqlmodel import asc, desc, select
 
 from app.database import get_db_session
+from app.dependencies import require_user
 from app.models.review import (
     PaginatedReviewsResponse,
     Review,
@@ -18,7 +19,11 @@ from app.models.user_profile import UserProfile
 router = APIRouter(prefix='/review', tags=['User Review'])
 
 
-@router.get('/', response_model=list[ReviewRead] | PaginatedReviewsResponse)
+@router.get(
+    '/',
+    response_model=list[ReviewRead] | PaginatedReviewsResponse,
+    dependencies=[Depends(require_user)],
+)
 def get_reviews(
     db_session: Annotated[DBSession, Depends(get_db_session)],
     limit: Optional[int] = Query(None),
@@ -97,7 +102,7 @@ def get_reviews(
     )
 
 
-@router.post('/', response_model=ReviewResponse)
+@router.post('/', response_model=ReviewResponse, dependencies=[Depends(require_user)])
 def create_review(
     review: ReviewCreate, db_session: Annotated[DBSession, Depends(get_db_session)]
 ) -> ReviewResponse:

--- a/backend/app/routers/user_profile_stats_route.py
+++ b/backend/app/routers/user_profile_stats_route.py
@@ -1,10 +1,10 @@
 from typing import Annotated
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session as DBSession
 
 from app.database import get_db_session
+from app.dependencies import require_user
 from app.models.user_profile import UserProfile, UserStatisticsRead
 
 router = APIRouter(prefix='/user', tags=['User Stats'])
@@ -13,16 +13,9 @@ router = APIRouter(prefix='/user', tags=['User Stats'])
 @router.get('/', response_model=UserStatisticsRead)
 def get_user_stats(
     db_session: Annotated[DBSession, Depends(get_db_session)],
-    x_user_id: str = Header(...),  # Auth via header
-    # TODO: Adjust to the authentication token in the header
+    user_profile: Annotated[UserProfile, Depends(require_user)],
 ) -> UserStatisticsRead:
-    try:
-        user_id = UUID(x_user_id)
-    except ValueError as err:
-        raise HTTPException(
-            status_code=401, detail='Invalid or missing authentication token'
-        ) from err
-
+    user_id = user_profile.id
     user = db_session.get(UserProfile, user_id)
     if not user:
         raise HTTPException(status_code=404, detail='User not found')


### PR DESCRIPTION
## 🔍 Current Situation

Closes: #264 #265 #266 #267 #258 

## 💡 Proposed Solution

## 🚨 Implications

- Does this affect any APIs (add/remove/change endpoints)?
- Do other systems or teams depend on this behavior?
- Is there another PR (frontend or backend) that must be merged first?
- Did you deprecate/remove any feature or behavior?

## ✅ Local Testing Instructions

How can someone test your changes locally?
Please include:

- Any required environment variables.
- Sample curl/Postman requests.
- Steps to run test cases (if manual/integration testing is needed).

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [x] I confirmed that all new or changed **environment variables** are:

  - [ ] The app has been tested with the new environment variables removed (e.g. deleted from .env, app started in a fresh terminal).
  - [ ] Documented clearly in `.env.example` or a config file.
  - [ ] Defaulted sensibly (or fail-fast if truly required).
  - [ ] Communicated to other stakeholders (if needed).

- [x] All migrations or DB changes have been tested locally.
- [ ] I added or updated relevant unit/integration tests.
- [ ] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes

- Which parts of the code need extra attention?
- Is this a functional change, a refactor, or a cleanup?
- Any known issues or follow-up work?
