### PR TITLE
fix: enhance user goals and confidence scores structure, update user …

### DIFF
--- a/backend/app/data/dummy_data.py
+++ b/backend/app/data/dummy_data.py
@@ -81,7 +81,19 @@ def get_dummy_user_profiles() -> list[UserProfile]:
 def get_dummy_user_goals(user_profiles: list[UserProfile]) -> list[UserGoal]:
     return [
         UserGoal(goal=Goal.giving_constructive_feedback, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.managing_team_conflicts, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.performance_reviews, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.motivating_team_members, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.leading_difficult_conversations, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.communicating_organizational_change, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.develop_emotional_intelligence, user_id=user_profiles[0].id),
+        UserGoal(goal=Goal.giving_constructive_feedback, user_id=user_profiles[1].id),
         UserGoal(goal=Goal.managing_team_conflicts, user_id=user_profiles[1].id),
+        UserGoal(goal=Goal.performance_reviews, user_id=user_profiles[1].id),
+        UserGoal(goal=Goal.motivating_team_members, user_id=user_profiles[1].id),
+        UserGoal(goal=Goal.leading_difficult_conversations, user_id=user_profiles[1].id),
+        UserGoal(goal=Goal.communicating_organizational_change, user_id=user_profiles[1].id),
+        UserGoal(goal=Goal.develop_emotional_intelligence, user_id=user_profiles[1].id),
     ]
 
 
@@ -607,16 +619,16 @@ def get_dummy_user_confidence_scores(user_profiles: list[UserProfile]) -> list[U
     scores = []
     areas = list(ConfidenceArea)  # ['giving_difficult_feedback', 'managing_team_conflicts', ...]
 
-    for i, user in enumerate(user_profiles):
-        assigned_area = areas[i % len(areas)]
-        scores.append(
-            UserConfidenceScore(
-                confidence_area=assigned_area,
-                user_id=user.id,
-                score=50,
-                updated_at=datetime.now(UTC),
+    for user in user_profiles:
+        for area in areas:
+            scores.append(
+                UserConfidenceScore(
+                    confidence_area=area,
+                    user_id=user.id,
+                    score=50,
+                    updated_at=datetime.now(UTC),
+                )
             )
-        )
     return scores
 
 

--- a/backend/app/models/user_confidence_score.py
+++ b/backend/app/models/user_confidence_score.py
@@ -22,7 +22,8 @@ class ConfidenceArea(str, Enum):
 
 
 class UserConfidenceScore(CamelModel, table=True):
-    confidence_area: ConfidenceArea = Field(default=ConfidenceArea.giving_difficult_feedback)
+    confidence_area: ConfidenceArea = Field(default=ConfidenceArea.giving_difficult_feedback,
+                                            primary_key=True)
     user_id: UUID = Field(foreign_key='userprofile.id', primary_key=True)
     score: int
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/app/models/user_confidence_score.py
+++ b/backend/app/models/user_confidence_score.py
@@ -22,8 +22,9 @@ class ConfidenceArea(str, Enum):
 
 
 class UserConfidenceScore(CamelModel, table=True):
-    confidence_area: ConfidenceArea = Field(default=ConfidenceArea.giving_difficult_feedback,
-                                            primary_key=True)
+    confidence_area: ConfidenceArea = Field(
+        default=ConfidenceArea.giving_difficult_feedback, primary_key=True
+    )
     user_id: UUID = Field(foreign_key='userprofile.id', primary_key=True)
     score: int
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/app/models/user_goal.py
+++ b/backend/app/models/user_goal.py
@@ -28,7 +28,7 @@ class Goal(str, Enum):
 
 
 class UserGoal(CamelModel, table=True):  # `table=True` makes it a database table
-    goal: Goal = Field(default=Goal.giving_constructive_feedback)
+    goal: Goal = Field(default=Goal.giving_constructive_feedback, primary_key=True)
     user_id: UUID = Field(foreign_key='userprofile.id', primary_key=True)  # FK to UserProfileModel
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/backend/app/models/user_profile.py
+++ b/backend/app/models/user_profile.py
@@ -11,13 +11,14 @@ from sqlmodel import Field, Relationship
 from app.models.camel_case import CamelModel
 from app.models.language import LanguageCode
 from app.models.user_confidence_score import ConfidenceScoreRead
+from app.models.user_goal import Goal
 
 if TYPE_CHECKING:
     from app.models.conversation_scenario import ConversationScenario
     from app.models.rating import Rating
     from app.models.review import Review
     from app.models.user_confidence_score import UserConfidenceScore
-    from app.models.user_goal import UserGoal
+    from app.models.user_goal import Goal, UserGoal
 
 
 class AccountRole(str, Enum):
@@ -91,7 +92,7 @@ class UserProfileUpdate(CamelModel):
     experience: Optional[Experience] = None
     preferred_learning_style: Optional[PreferredLearningStyle] = None
     store_conversations: Optional[bool] = None
-    goals: Optional[list[str]] = None
+    goals: Optional[list[Goal]] = None
     confidence_scores: Optional[list[ConfidenceScoreRead]] = None
 
 
@@ -102,7 +103,7 @@ class UserProfileReplace(CamelModel):
     experience: Experience
     preferred_learning_style: PreferredLearningStyle
     store_conversations: bool
-    goals: list[str]
+    goals: list[Goal]
     confidence_scores: list[ConfidenceScoreRead]
 
 
@@ -123,7 +124,7 @@ class UserProfileRead(CamelModel):
 
 
 class UserProfileExtendedRead(UserProfileRead):
-    goals: list[str]
+    goals: list[Goal]
     confidence_scores: list[ConfidenceScoreRead]
 
 

--- a/backend/app/routers/user_profile_route.py
+++ b/backend/app/routers/user_profile_route.py
@@ -211,6 +211,7 @@ def replace_user_profile(
     user.preferred_language_code = data.preferred_language_code
     user.preferred_learning_style = data.preferred_learning_style
     user.store_conversations = data.store_conversations
+    user.professional_role = data.professional_role
 
     db_session.add(user)
 
@@ -288,6 +289,8 @@ def update_user_profile(
         user.preferred_learning_style = update_data['preferred_learning_style']
     if 'store_conversations' in update_data:
         user.store_conversations = update_data['store_conversations']
+    if 'professional_role' in update_data:
+        user.professional_role = update_data['professional_role']
 
     db_session.add(user)
 
@@ -310,7 +313,7 @@ def update_user_profile(
             db_session.delete(cs)
         db_session.commit()
 
-        for cs_data in update_data['confidence_scores']:
+        for cs_data in data.confidence_scores:
             db_session.add(
                 UserConfidenceScore(
                     user_id=user.id,


### PR DESCRIPTION

## 🔍 Current Situation

-user.professional_role is not updated in both put, patch
-In UserGoal table, user_id is a primary key but it shouldnt be since a user can have multiple goals. Updating goals by an array of more than 1 goal gives 500.
-Same in UserConfidenceScore table, user_id is the primary key, although each user has 3 confidenceScores.

## 💡 Proposed Solution

updated models, dummy data and router

## 🚨 Implications

No conflicts with other components

## ✅ Local Testing Instructions

- run "uv run -m app.data.populate_dummy_data" to clean and populate data
- run "uv run fastapi dev" to open backend service
- try the put and patch endpoints of user_profile

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [ ] I confirmed that all new or changed **environment variables** are:

  - [ ] The app has been tested with the new environment variables removed (e.g. deleted from .env, app started in a fresh terminal).
  - [ ] Documented clearly in `.env.example` or a config file.
  - [ ] Defaulted sensibly (or fail-fast if truly required).
  - [ ] Communicated to other stakeholders (if needed).

- [x] All migrations or DB changes have been tested locally.
- [ ] I added or updated relevant unit/integration tests.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes
