### PR TITLE
Fix Session Deletes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -24,13 +23,9 @@ from app.routers import (
     user_profile_stats_route,
 )
 
-logging.basicConfig(
-    level=logging.INFO,
-    stream=sys.stdout,
-    format='%(message)s',
-)
+logging.basicConfig(level=logging.INFO)
 
-app = FastAPI(title='CoachAI', debug=settings.stage == 'dev')
+app = FastAPI(title='CoachAI', debug=True)
 
 app.add_middleware(
     CORSMiddleware,
@@ -39,6 +34,7 @@ app.add_middleware(
     allow_methods=['*'],
     allow_headers=['*'],
 )
+
 
 app.include_router(auth_route.router)
 app.include_router(conversation_category_route.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,9 +24,13 @@ from app.routers import (
     user_profile_stats_route,
 )
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    stream=sys.stdout,
+    format='%(message)s',
+)
 
-app = FastAPI(title='CoachAI', debug=True)
+app = FastAPI(title='CoachAI', debug=settings.stage == 'dev')
 
 app.add_middleware(
     CORSMiddleware,
@@ -34,7 +39,6 @@ app.add_middleware(
     allow_methods=['*'],
     allow_headers=['*'],
 )
-
 
 app.include_router(auth_route.router)
 app.include_router(conversation_category_route.router)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -45,7 +45,7 @@ class Session(CamelModel, table=True):  # `table=True` makes it a database table
         back_populates='session', cascade_delete=True
     )
     ratings: list['Rating'] = Relationship(back_populates='session', cascade_delete=True)
-    session_review: Optional['Review'] = Relationship(back_populates='session')
+    session_review: Optional['Review'] = Relationship(back_populates='session', cascade_delete=True)
     # Automatically update `updated_at` before an update
 
 


### PR DESCRIPTION
The delete /session/clear-all was trying to match /session/{session-id} and therefore failing. Also both delete failed because of the reference to foreign keys to rating and review.