### PR TITLE
fix(B-368): only one preparation per scenario and add some dummy scen…

### DIFF
--- a/backend/app/data/dummy_data.py
+++ b/backend/app/data/dummy_data.py
@@ -1026,9 +1026,10 @@ def get_dummy_session_feedback(
             questions_asked=7,
             session_length_s=2000,
             goals_achieved=[
-                'Bring clarity to the situation',
-                'Encourage open dialogue',
-                'Align on team roles',
+                'Maintain professionalism',
+                'Provide specific feedback',
+                'Foster mutual understanding',
+                'End on a positive note',
             ],
             example_positive=[
                 {
@@ -1421,6 +1422,51 @@ def get_dummy_scenario_preparations(
             prep_checklist=[
                 'Prepare project timeline',
                 'Review deliverables checklist',
+            ],
+            status=ScenarioPreparationStatus.completed,  # Use the enum for status
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        ),
+        ScenarioPreparation(
+            id=uuid4(),
+            scenario_id=conversation_scenarios[2].id,
+            objectives=[
+                'Bring clarity to the situation',
+                'Encourage open dialogue',
+                'Maintain professionalism',
+                'Align on team roles',
+                'Set expectations for communication',
+            ],
+            key_concepts=[
+                {'header': 'Time management', 'value': 'Time management'},
+                {'header': 'Collaboration', 'value': 'Collaboration'},
+            ],
+            prep_checklist=[
+                'Review client history',
+                'Prepare presentation slides',
+            ],
+            status=ScenarioPreparationStatus.completed,  # Use the enum for status
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        ),
+        ScenarioPreparation(
+            id=uuid4(),
+            scenario_id=conversation_scenarios[3].id,
+            objectives=[
+                'Bring clarity to the situation',
+                'Encourage open dialogue',
+                'Maintain professionalism',
+                'Provide specific feedback',
+                'Foster mutual understanding',
+                'End on a positive note',
+            ],
+            key_concepts=[
+                {'header': 'Time management', 'value': 'Time management'},
+                {'header': 'Collaboration', 'value': 'Collaboration'},
+            ],
+            prep_checklist=[
+                'Review client history',
+                'Prepare presentation slides',
             ],
             status=ScenarioPreparationStatus.completed,  # Use the enum for status
             created_at=datetime.now(UTC),

--- a/backend/app/models/conversation_scenario.py
+++ b/backend/app/models/conversation_scenario.py
@@ -54,7 +54,7 @@ class ConversationScenario(CamelModel, table=True):  # `table=True` makes it a d
         back_populates='conversation_scenarios'
     )
     sessions: list['Session'] = Relationship(back_populates='scenario', cascade_delete=True)
-    preparations: list['ScenarioPreparation'] = Relationship(
+    preparation: Optional['ScenarioPreparation'] = Relationship(
         back_populates='scenario', cascade_delete=True
     )
     user_profile: Optional['UserProfile'] = Relationship(back_populates='conversation_scenarios')

--- a/backend/app/models/scenario_preparation.py
+++ b/backend/app/models/scenario_preparation.py
@@ -37,7 +37,7 @@ class ScenarioPreparation(CamelModel, table=True):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
-    scenario: Optional['ConversationScenario'] = Relationship(back_populates='preparations')
+    scenario: Optional['ConversationScenario'] = Relationship(back_populates='preparation')
 
     # Automatically update `updated_at` before an update
 

--- a/backend/app/routers/session_route.py
+++ b/backend/app/routers/session_route.py
@@ -77,8 +77,8 @@ def get_session_by_id(
     else:
         training_title = conversation_scenario.custom_category_label
 
-    if conversation_scenario.preparations:
-        goals = conversation_scenario.preparations[0].objectives
+    if conversation_scenario.preparation:
+        goals = conversation_scenario.preparation.objectives
     else:
         goals = []
 


### PR DESCRIPTION
…ario preparation data

## 🔍 Current Situation

Closes: #368 

## 💡 Proposed Solution

- added more Scenario Preparations to the dummy data --> contain the objectives / goals

## 🚨 Implications

- Does this affect any APIs (add/remove/change endpoints)?
- Do other systems or teams depend on this behavior?
- Is there another PR (frontend or backend) that must be merged first?
- Did you deprecate/remove any feature or behavior?

--> No

## ✅ Local Testing Instructions

How can someone test your changes locally?
Please include:

- Any required environment variables.
- Sample curl/Postman requests.
- Steps to run test cases (if manual/integration testing is needed).

Check the GET session by id route --> the only one that was touched

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.

- [x] All migrations or DB changes have been tested locally.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes

- Which parts of the code need extra attention?
- Is this a functional change, a refactor, or a cleanup?
- Any known issues or follow-up work?
