### PR TITLE
feat(F-452): add link to privacy and terms in signup

### DIFF
--- a/frontend/messages/de/Login.json
+++ b/frontend/messages/de/Login.json
@@ -35,7 +35,11 @@
     "passwordInputRequirementThreeLabel": "Mindestens ein Sonderzeichen (!@#$%^&*)",
     "gdprAdherenceText": "Wir halten uns strikt an die DSGVO, indem wir nur erforderliche Daten erheben, nichts Unnötiges speichern und Daten so schnell wie möglich löschen. ",
     "readMoreOnGdprLink": "Mehr erfahren",
-    "agreeToTermsCheckboxLabel": "Ich stimme den Nutzungsbedingungen und der Datenschutzrichtlinie zu",
+    "agreeToTermsCheckboxLabel": "Ich stimme den",
+    "termsOfServiceLink": "Nutzungsbedingungen",
+    "andText": "und der",
+    "privacyPolicyLink": "Datenschutzerklärung",
+    "toText": "zu",
     "signUpButtonLabel": "Registrieren",
     "signUpWithGoogleButtonLabel": "Oder mit Google registrieren",
     "genericError": "Ein Fehler ist während der Registrierung aufgetreten"

--- a/frontend/messages/en/Login.json
+++ b/frontend/messages/en/Login.json
@@ -35,7 +35,11 @@
     "passwordInputRequirementThreeLabel": "At least one special character (!@#$%^&*)",
     "gdprAdherenceText": "We strictly adhere to GDPR by collecting only essential data, storing nothing unnecessary, and deleting data as soon as possible. ",
     "readMoreOnGdprLink": "read more",
-    "agreeToTermsCheckboxLabel": "I agree to the Terms of Service and Privacy Policy",
+    "agreeToTermsCheckboxLabel": "I agree to the",
+    "termsOfServiceLink": "Terms of Service",
+    "andText": "and",
+    "privacyPolicyLink": "Privacy Policy",
+    "toText": "",
     "signUpButtonLabel": "Sign Up",
     "signUpWithGoogleButtonLabel": "Or Sign Up With Google",
     "genericError": "An error occurred during sign up"

--- a/frontend/src/app/[locale]/(auth)/login/components/SignUpForm.tsx
+++ b/frontend/src/app/[locale]/(auth)/login/components/SignUpForm.tsx
@@ -23,6 +23,7 @@ import { VerificationPopup } from '@/app/[locale]/(auth)/login/components/Verifi
 import { PasswordInput } from '@/app/[locale]/(auth)/login/components/PasswordInput';
 import PrivacyDialog from '@/app/[locale]/(auth)/login/components/PrivacyDialog';
 import { showErrorToast } from '@/lib/toast';
+import Link from 'next/link';
 
 export function SignUpForm() {
   const t = useTranslations('Login.SignUpTab');
@@ -201,7 +202,27 @@ export function SignUpForm() {
                           disabled={isLoading}
                         />
                       </FormControl>
-                      <FormLabel>{t('agreeToTermsCheckboxLabel')}</FormLabel>
+                      <FormLabel className="text-sm">
+                        {t('agreeToTermsCheckboxLabel')}{' '}
+                        <Link
+                          href="/terms"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-bw-60 hover:text-bw-50 underline"
+                        >
+                          {t('termsOfServiceLink')}
+                        </Link>{' '}
+                        {t('andText')}{' '}
+                        <Link
+                          href="/privacy"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-bw-60 hover:text-bw-50 underline"
+                        >
+                          {t('privacyPolicyLink')}
+                        </Link>{' '}
+                        {t('toText')}
+                      </FormLabel>
                     </div>
                   </FormItem>
                 )}


### PR DESCRIPTION
# add link to privacy and terms in signup
### Current Situation
No access to the privacy policy and terms of service in the signup form even though users need to accept
### Proposed Solution
Link to privacy policy and terms of service pages in form
#### Implications
No implications
### Testing
Manual testing ensuring links work and desired UI
### Reviewer Notes
Review style