### PR TITLE
fix(F-455): Rename Training Setttings Page

### DIFF
--- a/frontend/messages/de/TrainingSettings.json
+++ b/frontend/messages/de/TrainingSettings.json
@@ -1,7 +1,7 @@
 {
-  "metaTitle": "Trainingsseinstellungen - Coach AI",
+  "metaTitle": "Einstellungen - Coach AI",
   "metaDescription": "Passen Sie Ihre Trainingsseinstellungen an",
-  "title": "Trainingseinstellungen",
+  "title": "Einstellungen",
   "backToDashboard": "Zurück zum Dashboard",
   "privacyControls": "Datenschutzeinstellungen",
   "storeAudioTranscripts": "Gesprächsaudio und Transkripte speichern",

--- a/frontend/messages/en/TrainingSettings.json
+++ b/frontend/messages/en/TrainingSettings.json
@@ -1,7 +1,7 @@
 {
-  "metaTitle": "Training Settings - Coach AI",
+  "metaTitle": "Settings - Coach AI",
   "metaDescription": "Customize your training preferences and goals",
-  "title": "Training Settings",
+  "title": "Settings",
   "backToDashboard": "Back to Dashboard",
   "privacyControls": "Privacy Controls",
   "storeAudioTranscripts": "Store Conversation Audio and Transcripts",

--- a/frontend/src/app/[locale]/(main)/training-settings/loading.tsx
+++ b/frontend/src/app/[locale]/(main)/training-settings/loading.tsx
@@ -4,7 +4,7 @@ export default function TrainingSettingsLoadingPage() {
   return (
     <div>
       <div className="flex items-center justify-between">
-        <div className="text-xl font-bold text-gray-700">Training Settings</div>
+        <div className="text-xl font-bold text-gray-700">Settings</div>
         <Link href="/dashboard">
           <button className="px-3 py-2 bg-gray-200 rounded text-gray-700 text-sm">
             Back to Dashboard


### PR DESCRIPTION
# Rename Training Setttings Page
### Current Situation
The page is called "Training Settings"
### Proposed Solution
Renamed the page with the translations to "Settings"
### Testing
Currently unable to test manually, due to complications connecting to the backend.
### Reviewer Notes
Check if it works as expected.
