### PR TITLE
fix(F-520): add missing translations for code length verification

### DIFF
--- a/frontend/messages/de/Login.json
+++ b/frontend/messages/de/Login.json
@@ -51,6 +51,7 @@
     "verifyButtonLabel": "Bestätigen",
     "verifyingButtonLabel": "Wird überprüft...",
     "cancelButtonLabel": "Abbrechen",
+    "codeLengthError": "Der Code muss 6 Zeichen lang sein",
     "genericError": "Bei der Überprüfung ist ein Fehler aufgetreten"
   },
   "PrivacyPolicyDialog": {

--- a/frontend/messages/en/Login.json
+++ b/frontend/messages/en/Login.json
@@ -51,6 +51,7 @@
     "verifyButtonLabel": "Verify",
     "verifyingButtonLabel": "Verifying...",
     "cancelButtonLabel": "Cancel",
+    "codeLengthError": "The code must be 6 characters long",
     "genericError": "An error occurred during verification"
   },
   "PrivacyPolicyDialog": {


### PR DESCRIPTION
# Descriptive Title
### Current Situation
- Missing translation key for code length verification

### Proposed Solution
- Added missing translations

#### Implications
- No implications

### Testing
- The error should have disappeared when creating a new account

### Reviewer Notes
- No reviewer notes
