### PR TITLE
feat(F-509): disable buttons after submitting and add loading states

### DIFF
--- a/frontend/messages/de/ConversationScenario.json
+++ b/frontend/messages/de/ConversationScenario.json
@@ -98,7 +98,8 @@
   "navigation": {
     "back": "Zurück",
     "next": "Weiter",
-    "create": "Training erstellen"
+    "create": "Training erstellen",
+    "creating": "Wird erstellt..."
   },
   "errorMessage": "Fehler beim Erstellen des Szenarios. Bitte versuchen Sie es später erneut."
 }

--- a/frontend/messages/de/Feedback.json
+++ b/frontend/messages/de/Feedback.json
@@ -7,6 +7,7 @@
     "title": "Bewertung",
     "description": "Wie war die Trainingssitzung? Helfen Sie uns, indem Sie Ihre Bewertung abgeben.",
     "rate": "Bewertung abgeben",
+    "submitting": "Wird abgegeben...",
     "submitReviewError": "Fehler beim Abgeben der Bewertung. Bitte versuchen Sie es später erneut.",
     "submitReviewSuccess": "Bewertung erfolgreich abgegeben. Vielen Dank für Ihre Bewertung!"
   },

--- a/frontend/messages/de/Preparation.json
+++ b/frontend/messages/de/Preparation.json
@@ -20,7 +20,8 @@
   },
   "navigation": {
     "back": "Zurück",
-    "start": "Training starten"
+    "start": "Training starten",
+    "starting": "Wird gestartet..."
   },
   "loadingText": "Bereite Ziele und Checkliste vor...",
   "sessionCreationError": "Fehler beim Erstellen der Trainingssitzung. Bitte versuchen Sie es später erneut.",

--- a/frontend/messages/de/Settings.json
+++ b/frontend/messages/de/Settings.json
@@ -11,6 +11,7 @@
   "requestDeletion": "Löschung anfordern",
   "personalizationSettings": "Personalisierungseinstellungen",
   "saveSettings": "Einstellungen speichern",
+  "saving": "Wird gespeichert...",
   "ninetyDays": "Ihre Audiodateien und Transkripte werden für 90 Tage gespeichert und sind im Trainingsverlauf einsehbar.",
   "zeroDays": "Ihre Audiodateien und Transkripte werden nicht gespeichert.",
   "deleteAccountConfirmTitle": "Sind Sie sicher?",

--- a/frontend/messages/en/ConversationScenario.json
+++ b/frontend/messages/en/ConversationScenario.json
@@ -91,7 +91,8 @@
   "navigation": {
     "back": "Go Back",
     "next": "Next Step",
-    "create": "Create Training"
+    "create": "Create Training",
+    "creating": "Creating..."
   },
   "errorMessage": "An error occurred while creating the scenario. Please try again later."
 }

--- a/frontend/messages/en/Feedback.json
+++ b/frontend/messages/en/Feedback.json
@@ -7,6 +7,7 @@
     "title": "Review",
     "description": "How was the training session? Help us improve by providing your review.",
     "rate": "Submit Review",
+    "submitting": "Submitting...",
     "submitReviewError": "Error while submitting review. Please try again later.",
     "submitReviewSuccess": "Review submitted successfully. Thank you for your review!"
   },

--- a/frontend/messages/en/Preparation.json
+++ b/frontend/messages/en/Preparation.json
@@ -20,7 +20,8 @@
   },
   "navigation": {
     "back": "Go Back",
-    "start": "Start Training"
+    "start": "Start Training",
+    "starting": "Starting..."
   },
   "loadingText": "Preparing Objectives and Checklist...",
   "sessionCreationError": "Error creating training session. Please try again later.",

--- a/frontend/messages/en/Settings.json
+++ b/frontend/messages/en/Settings.json
@@ -11,6 +11,7 @@
   "requestDeletion": "Request Deletion",
   "personalizationSettings": "Personalization Settings",
   "saveSettings": "Save Settings",
+  "saving": "Saving...",
   "ninetyDays": "Your audio and transcripts will be retained and viewable in the training history for 90 days.",
   "zeroDays": "Your audio and transcripts will not be saved.",
   "deleteAccountConfirmTitle": "Are you sure?",

--- a/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
+++ b/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
@@ -21,6 +21,7 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
   const t = useTranslations('Feedback.reviewDialog');
   const [rating, setRating] = useState(0);
   const [ratingDescription, setRatingDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const resetForm = () => {
     setRating(0);
@@ -34,6 +35,10 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
   };
 
   const rateFeedback = async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     try {
       await reviewService.createReview({
         rating,
@@ -43,6 +48,8 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
       showSuccessToast(t('submitReviewSuccess'));
     } catch (error) {
       showErrorToast(error, t('submitReviewError'));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -76,9 +83,9 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
           <Button
             variant={rating ? 'default' : 'disabled'}
             onClick={rateFeedback}
-            disabled={!rating}
+            disabled={!rating || isSubmitting}
           >
-            {t('rate')}
+            {isSubmitting ? t('submitting') : t('rate')}
           </Button>
         </DialogClose>
       </DialogContent>

--- a/frontend/src/app/[locale]/(main)/new-conversation-scenario/components/ConversationScenarioForm.tsx
+++ b/frontend/src/app/[locale]/(main)/new-conversation-scenario/components/ConversationScenarioForm.tsx
@@ -34,6 +34,7 @@ export default function ConversationScenarioForm() {
   const { locale } = useParams();
   const [currentStep, setCurrentStep] = useState(0);
   const [formState, setFormState] = useState<ConversationScenarioFormState>(initialFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const steps = [t('steps.category'), t('steps.situation'), t('steps.customize')];
   const [categories, setCategories] = useState<ConversationCategory[]>(
     t.raw('categories') as ConversationCategory[]
@@ -125,6 +126,10 @@ export default function ConversationScenarioForm() {
       return;
     }
 
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     const scenario: ConversationScenario = {
       categoryId: formState.category,
       customCategoryLabel: formState.customCategory,
@@ -142,7 +147,19 @@ export default function ConversationScenarioForm() {
       router.push(`/preparation/${data.scenarioId}`);
     } catch (error) {
       showErrorToast(error, t('errorMessage'));
+    } finally {
+      setIsSubmitting(false);
     }
+  };
+
+  const getButtonText = () => {
+    if (isSubmitting && currentStep === 2) {
+      return t('navigation.creating');
+    }
+    if (currentStep === 2) {
+      return t('navigation.create');
+    }
+    return t('navigation.next');
   };
 
   return (
@@ -207,8 +224,9 @@ export default function ConversationScenarioForm() {
           size="full"
           onClick={() => submitForm()}
           variant={!isStepValid(currentStep) ? 'disabled' : 'default'}
+          disabled={isSubmitting || !isStepValid(currentStep)}
         >
-          {currentStep === 2 ? t('navigation.create') : t('navigation.next')}
+          {getButtonText()}
           <ArrowRightIcon />
         </Button>
       </div>

--- a/frontend/src/app/[locale]/(main)/preparation/[id]/components/CreateSessionButton.tsx
+++ b/frontend/src/app/[locale]/(main)/preparation/[id]/components/CreateSessionButton.tsx
@@ -7,24 +7,32 @@ import { useTranslations } from 'next-intl';
 import { CreateSessionButtonProps } from '@/interfaces/CreateSessionButtonProps';
 import { useRouter } from 'next/navigation';
 import { showErrorToast } from '@/lib/toast';
+import { useState } from 'react';
 
 export const CreateSessionButton = ({ scenarioId }: CreateSessionButtonProps) => {
   const t = useTranslations('Preparation');
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleCreateSession = async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     try {
       const { data } = await sessionService.createSession(scenarioId);
       router.push(`/simulation/${data.id}`);
     } catch (error) {
       showErrorToast(error, t('sessionCreationError'));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
-    <Button onClick={handleCreateSession} size="full">
+    <Button onClick={handleCreateSession} size="full" disabled={isSubmitting}>
       <Play />
-      {t('navigation.start')}
+      {isSubmitting ? t('navigation.starting') : t('navigation.start')}
     </Button>
   );
 };

--- a/frontend/src/app/[locale]/(main)/settings/components/Settings.tsx
+++ b/frontend/src/app/[locale]/(main)/settings/components/Settings.tsx
@@ -56,6 +56,7 @@ export default function Settings({ userProfile }: { userProfile: Promise<UserPro
   const [conversation, setConversation] = useState(
     getConfidenceScores(userProfileData, 'leading_challenging_conversations')
   );
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const confidenceFieldsProps = {
     difficulty,
@@ -86,6 +87,10 @@ export default function Settings({ userProfile }: { userProfile: Promise<UserPro
   };
 
   const handleSaveSettings = async () => {
+    if (isSubmitting) return;
+
+    setIsSubmitting(true);
+
     try {
       await UserProfileService.updateUserProfile({
         fullName: userProfileData.fullName,
@@ -101,6 +106,8 @@ export default function Settings({ userProfile }: { userProfile: Promise<UserPro
       showSuccessToast(t('saveSettingsSuccess'));
     } catch (error) {
       showErrorToast(error, t('saveSettingsError'));
+    } finally {
+      setIsSubmitting(false);
     }
   };
   return (
@@ -179,8 +186,8 @@ export default function Settings({ userProfile }: { userProfile: Promise<UserPro
           </AccordionItem>
         </Accordion>
       </div>
-      <Button size="full" onClick={handleSaveSettings}>
-        {t('saveSettings')}
+      <Button size="full" onClick={handleSaveSettings} disabled={isSubmitting}>
+        {isSubmitting ? t('saving') : t('saveSettings')}
       </Button>
     </div>
   );


### PR DESCRIPTION
# Disable action buttons after request submission to prevent multiple requests
### Current Situation
Buttons could be clicked multiple times resulting in multiple requests.
### Proposed Solution
Disabled buttons after submitting and add loading states to buttons.
#### Implications
No dependencies or implications
### Testing
Manual testing
### Reviewer Notes
Review the loading states and ensure buttons work as before
