### PR TITLE
feat(F-456): add checkbox to share session with admin

### DIFF
--- a/frontend/messages/de/Feedback.json
+++ b/frontend/messages/de/Feedback.json
@@ -9,7 +9,8 @@
     "rate": "Bewertung abgeben",
     "submitting": "Wird abgegeben...",
     "submitReviewError": "Fehler beim Abgeben der Bewertung. Bitte versuchen Sie es später erneut.",
-    "submitReviewSuccess": "Bewertung erfolgreich abgegeben. Vielen Dank für Ihre Bewertung!"
+    "submitReviewSuccess": "Bewertung erfolgreich abgegeben. Vielen Dank für Ihre Bewertung!",
+    "shareWithAdmin": "Sitzung zur Verbesserung mit einem Administrator teilen."
   },
   "progressBars": {
     "structure": "Struktur",

--- a/frontend/messages/en/Feedback.json
+++ b/frontend/messages/en/Feedback.json
@@ -9,7 +9,8 @@
     "rate": "Submit Review",
     "submitting": "Submitting...",
     "submitReviewError": "Error while submitting review. Please try again later.",
-    "submitReviewSuccess": "Review submitted successfully. Thank you for your review!"
+    "submitReviewSuccess": "Review submitted successfully. Thank you for your review!",
+    "shareWithAdmin": "Share session with an admin for improvement."
   },
   "progressBars": {
     "structure": "Structure",

--- a/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
+++ b/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/Dialog';
 import { Rating, RatingButton } from '@/components/ui/Rating';
 import { Textarea } from '@/components/ui/Textarea';
+import Checkbox from '@/components/ui/Checkbox';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import { reviewService } from '@/services/client/ReviewService';
 import { useTranslations } from 'next-intl';
@@ -22,10 +23,12 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
   const [rating, setRating] = useState(0);
   const [ratingDescription, setRatingDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [shareWithAdmin, setShareWithAdmin] = useState(false);
 
   const resetForm = () => {
     setRating(0);
     setRatingDescription('');
+    setShareWithAdmin(false);
   };
 
   const handleOpenChange = (open: boolean) => {
@@ -78,6 +81,16 @@ export default function ReviewDialog({ sessionId }: { sessionId: string }) {
           value={ratingDescription}
           onChange={(e) => setRatingDescription(e.target.value)}
         />
+
+        {/* Share with Admin Checkbox */}
+        <div className="flex items-center space-x-2 mt-4">
+          <Checkbox
+            checked={shareWithAdmin}
+            onClick={() => setShareWithAdmin(!shareWithAdmin)}
+            disabled={isSubmitting}
+          />
+          <label className="text-sm text-bw-70">{t('shareWithAdmin')}</label>
+        </div>
 
         <DialogClose asChild>
           <Button


### PR DESCRIPTION
# Descriptive Title
### Current Situation
---

### Proposed Solution
- Added a checkbox so the user can decide whether to share a session with an admin or not
<img width="534" alt="Screenshot 2025-06-23 at 02 53 46" src="https://github.com/user-attachments/assets/bc1356fa-9b5f-4d51-bc48-fee999e6913d" />

#### Implications
- No implications

### Testing
- No need to check for integration with backend, as this is out of the scope of this PR

### Reviewer Notes
- No reviewer notes
