### PR TITLE
Populate vector db with knowledge sources

### DIFF
--- a/backend/app/connections/gemini_client.py
+++ b/backend/app/connections/gemini_client.py
@@ -11,11 +11,11 @@ DEFAULT_MODEL = 'gemini-2.0-flash'
 GEMINI_API_KEY = settings.GEMINI_API_KEY
 
 
-def _is_valid_api_key(key: str | None) -> bool:
+def is_valid_api_key(key: str | None) -> bool:
     return bool(key and isinstance(key, str) and key.strip())
 
 
-if not _is_valid_api_key(GEMINI_API_KEY):
+if not is_valid_api_key(GEMINI_API_KEY):
     print(
         '[WARNING] GEMINI_API_KEY is missing or invalid. '
         'AI features will be disabled and mock responses will be used.'

--- a/backend/app/data/populate_vector_db.py
+++ b/backend/app/data/populate_vector_db.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from app.config import Settings
+from app.connections.gemini_client import is_valid_api_key
+from app.rag.embeddings import get_embedding_model
+from app.rag.rag import load_and_index_documents
+from app.rag.vector_db import load_vector_db
+
+settings = Settings()
+
+EMBEDDING_TYPE = 'gemini'
+TABLE_NAME = 'hr_information'
+BASE_DIR = Path(__file__).parent
+DOC_FOLDER = BASE_DIR / 'documents'
+
+
+def populate_vector_db(table_name: str = TABLE_NAME, doc_folder: str = DOC_FOLDER) -> None:
+    embedding = get_embedding_model(EMBEDDING_TYPE)
+    vector_db = load_vector_db(embedding, table_name)
+    load_and_index_documents(vector_db, doc_folder, table_name)
+
+
+if __name__ == '__main__':
+    if not is_valid_api_key(settings.GEMINI_API_KEY):
+        print(
+            "Can't populate vector database. No valid GEMINI API KEY available! "
+            'Please update your .env and rerun the script'
+        )
+        exit()
+    if not settings.SUPABASE_URL or len(settings.SUPABASE_URL) == 0:
+        print(
+            "Can't populate vector database. No SUPABASE URL available! "
+            'Please update your .env and rerun the script'
+        )
+        exit()
+    supabase_url = settings.SUPABASE_URL
+
+    table_name_user = input(
+        "Enter the table name (press Enter for default 'hr_information'): "
+    ).strip()
+    if not table_name_user:
+        table_name_user = 'hr_information'
+
+    doc_folder_user = input(
+        f"Enter the path to the document directory (press Enter for default '{DOC_FOLDER}'): "
+    ).strip()
+    if not doc_folder_user:
+        doc_folder_user = '/documents'
+
+    # Show Supabase URL from environment and confirm
+    print(f"\nSupabase URL from settings: '{supabase_url}'")
+    confirm = input('Do you want to proceed with this Supabase URL? (y/n): ').strip().lower()
+    if confirm != 'y':
+        print(
+            'If you want to change the Supabase URL, '
+            'please update your .env file and restart the script.'
+        )
+        exit()
+
+    # Final configuration output
+    print('\nUsing the following configuration:')
+    print(f'Table Name: {table_name_user}')
+    print(f'Document Folder: {doc_folder_user}')
+    print(f'Supabase URL: {supabase_url}')
+
+    populate_vector_db()

--- a/backend/app/rag/populate_vector_db.py
+++ b/backend/app/rag/populate_vector_db.py
@@ -42,12 +42,11 @@ if __name__ == '__main__':
         table_name_user = 'hr_information'
 
     doc_folder_user = input(
-        f"Enter the path to the document directory (press Enter for default '{DOC_FOLDER}'): "
+        f"\nEnter the path to the document directory (press Enter for default '{DOC_FOLDER}'): "
     ).strip()
     if not doc_folder_user:
-        doc_folder_user = '/documents'
+        doc_folder_user = DOC_FOLDER
 
-    # Show Supabase URL from environment and confirm
     print(f"\nSupabase URL from settings: '{supabase_url}'")
     confirm = input('Do you want to proceed with this Supabase URL? (y/n): ').strip().lower()
     if confirm != 'y':
@@ -63,4 +62,4 @@ if __name__ == '__main__':
     print(f'Document Folder: {doc_folder_user}')
     print(f'Supabase URL: {supabase_url}')
 
-    populate_vector_db()
+    populate_vector_db(table_name=table_name_user, doc_folder=doc_folder_user)

--- a/backend/app/rag/populate_vector_db.py
+++ b/backend/app/rag/populate_vector_db.py
@@ -14,10 +14,10 @@ BASE_DIR = Path(__file__).parent
 DOC_FOLDER = BASE_DIR / 'documents'
 
 
-def populate_vector_db(table_name: str = TABLE_NAME, doc_folder: str = DOC_FOLDER) -> None:
+def populate_vector_db(doc_folder: str = DOC_FOLDER) -> None:
     embedding = get_embedding_model(EMBEDDING_TYPE)
-    vector_db = load_vector_db(embedding, table_name)
-    load_and_index_documents(vector_db, doc_folder, table_name)
+    vector_db = load_vector_db(embedding)
+    load_and_index_documents(vector_db, doc_folder)
 
 
 if __name__ == '__main__':
@@ -35,14 +35,9 @@ if __name__ == '__main__':
         exit()
     supabase_url = settings.SUPABASE_URL
 
-    table_name_user = input(
-        "Enter the table name (press Enter for default 'hr_information'): "
-    ).strip()
-    if not table_name_user:
-        table_name_user = 'hr_information'
-
     doc_folder_user = input(
-        f"\nEnter the path to the document directory (press Enter for default '{DOC_FOLDER}'): "
+        f'\nEnter the absolute path to the document directory (press Enter '
+        f"for default '{DOC_FOLDER}'): "
     ).strip()
     if not doc_folder_user:
         doc_folder_user = DOC_FOLDER
@@ -58,8 +53,8 @@ if __name__ == '__main__':
 
     # Final configuration output
     print('\nUsing the following configuration:')
-    print(f'Table Name: {table_name_user}')
+    print(f'Table Name: {TABLE_NAME}')
     print(f'Document Folder: {doc_folder_user}')
     print(f'Supabase URL: {supabase_url}')
 
-    populate_vector_db(table_name=table_name_user, doc_folder=doc_folder_user)
+    populate_vector_db(doc_folder=doc_folder_user)

--- a/backend/app/rag/rag.py
+++ b/backend/app/rag/rag.py
@@ -35,7 +35,9 @@ DEFAULT_PROMPT = """
 DEFAULT_POPULATE_DB = False
 
 
-def load_and_index_documents(vector_db: SupabaseVectorStore) -> None:
+def load_and_index_documents(
+    vector_db: SupabaseVectorStore, doc_folder: str = DOC_FOLDER, table_name: str = TABLE_NAME
+) -> None:
     """
     Loads and indexes PDF documents from the configured folder into the provided vector store.
 
@@ -46,15 +48,16 @@ def load_and_index_documents(vector_db: SupabaseVectorStore) -> None:
 
     Parameters:
         vector_db (SupabaseVectorStore): The vector store where documents will be added.
+        doc_folder (str): The folder where the documents are stored.
     """
-    os.makedirs(DOC_FOLDER, exist_ok=True)
-    docs = prepare_vector_db_docs(str(DOC_FOLDER))
+    os.makedirs(doc_folder, exist_ok=True)
+    docs = prepare_vector_db_docs(str(doc_folder))
     if not docs:
-        print(f'⚠️ No documents found in folder: {DOC_FOLDER}')
+        print(f'⚠️ No documents found in folder: {doc_folder}')
         return
 
     vector_db.add_documents(docs)
-    print(f'Added {len(docs)} documents to vector store: {TABLE_NAME}')
+    print(f'Added {len(docs)} documents to vector store: {table_name}')
 
 
 def build_vector_db_retriever(

--- a/backend/app/rag/vector_db.py
+++ b/backend/app/rag/vector_db.py
@@ -90,7 +90,7 @@ def get_supabase_client() -> Client:
 
 
 def load_vector_db(
-    embedding: Embeddings, table_name: str, query_name: str = 'match_documents'
+    embedding: Embeddings, table_name: str = 'hr_information', query_name: str = 'match_documents'
 ) -> SupabaseVectorStore:
     """
     Initializes a SupabaseVectorStore with the given embedding model and configuration.


### PR DESCRIPTION
### Current Situation
There is no script to populate the vector knowledge base with documents from an arbitrary path
### Proposed Solution
Closes #483 
`app.rag.populate_vector_db.py` is a script that populates the knowledge base table "hr_information", accessed from the Supabase url from `.env`. The documents come from a user-specified folder path
### Testing
Tested manually by running `uv run -m app.rag.populate_vector_db`

