### PR TITLE
fix(F-539): fix global padding for all pages and app header

### DIFF
--- a/frontend/src/app/[locale]/(main)/layout.tsx
+++ b/frontend/src/app/[locale]/(main)/layout.tsx
@@ -34,7 +34,7 @@ export default async function RootLayout({ children, params }: LayoutProps) {
         <NextIntlClientProvider>
           <UserContextProvider user={userProfile}>
             <AppHeader />
-            <main className="container mx-auto p-6 md:p-12 mt-16">
+            <main className="mx-auto p-[clamp(1.25rem,4vw,4rem)] max-w-8xl mt-16">
               <BackButton />
               {children}
             </main>

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -45,7 +45,7 @@ export function AppHeader() {
   return (
     <>
       <header className="fixed top-0 left-0 right-0 bg-background z-50 shadow">
-        <div className="container flex h-16 items-center justify-between mx-auto px-4">
+        <div className="flex h-16 items-center justify-between mx-auto px-[clamp(1.25rem,4vw,4rem)] max-w-8xl">
           <Link
             href="/dashboard"
             className="text-bw-70 text-xl font-semibold"
@@ -53,8 +53,9 @@ export function AppHeader() {
           >
             {t('title')}
           </Link>
-          <div className="flex items-center gap-0 md:gap-4">
-            <div className="hidden md:flex items-center gap-6">
+          <div className="flex items-center gap-4">
+            {/* Navigation Elements */}
+            <div className="hidden lg:flex items-center gap-10">
               {navigationLinks.map(({ key, href }) => (
                 <Link
                   key={key}
@@ -68,8 +69,9 @@ export function AppHeader() {
               ))}
             </div>
             <LanguageSwitcher />
+            {/* Burger Menu Item */}
             <Button
-              className="md:hidden pl-0"
+              className="lg:hidden p-0"
               variant="ghost"
               size="icon"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
@@ -78,7 +80,7 @@ export function AppHeader() {
             </Button>
             <Button
               variant="secondary"
-              className="hidden md:flex h-8"
+              className="hidden lg:flex h-8"
               onClick={async () => {
                 await authService.logoutUser();
               }}


### PR DESCRIPTION
# Descriptive Title
### Current Situation
- It turned out there is no 'error' with the margins, but rather padding transitions which are quite 'abrupt'

### Proposed Solution
Redefined the padding rules: 
- There is a max width for the content, if the screen width is too large
- When decreasing the viewpoint width, the paddings stay the same, rather than changing abruptly
- When decreasing it even more, the padding itself also decreases with a constant rate, until reaching a min-padding

- AppHeader menu now collapses at `lg:` breakpoint instead of `md:`, allowing a greater margin between the nav items and therefore "more space to breathe"
- Paddings of pages & app header are now consistent

![Uploading Screenshot 2025-06-24 at 23.22.06.png…]()


#### Implications
- No implications

### Testing
- Slowly in-/decrease the viewpoint width
- Observe how the paddings and app header layout change

### Reviewer Notes
- No reviewer notes
