### PR TITLE
feat(M-477): add supabase delete user to delete user endpoint

### DIFF
--- a/backend/app/data/dummy_data.py
+++ b/backend/app/data/dummy_data.py
@@ -4,9 +4,10 @@ from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from gotrue import AdminUserAttributes
-from supabase import AuthError, create_client
+from supabase import AuthError
 
 from app.config import settings
+from app.database import supabase
 from app.interfaces import MockUserIdsEnum
 from app.models.admin_dashboard_stats import AdminDashboardStats
 from app.models.app_config import AppConfig, ConfigType
@@ -1538,8 +1539,6 @@ def get_mock_user_data() -> tuple[AdminUserAttributes, AdminUserAttributes]:
 
 
 def create_mock_users() -> None:
-    supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_ROLE_KEY)
-
     attributes, admin_attributes = get_mock_user_data()
 
     # Create mock user
@@ -1556,7 +1555,6 @@ def create_mock_users() -> None:
 
 
 def delete_mock_users() -> None:
-    supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_ROLE_KEY)
     for user_id in [MockUserIdsEnum.USER.value, MockUserIdsEnum.ADMIN.value]:
         try:
             supabase.auth.admin.delete_user(user_id.__str__())

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from sqlmodel import Session as DBSession
 from sqlmodel import SQLModel, create_engine
+from supabase import Client, create_client
 
 from app.config import Settings
 
@@ -37,3 +38,10 @@ def get_db_session() -> Generator[DBSession, Any, None]:
             yield db_session
         finally:
             db_session.close()
+
+
+def get_supabase_client() -> Client:
+    return create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_ROLE_KEY)
+
+
+supabase: Client = get_supabase_client()

--- a/backend/app/rag/vector_db.py
+++ b/backend/app/rag/vector_db.py
@@ -5,9 +5,9 @@ from langchain.schema import Document
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders import PyPDFLoader
 from langchain_community.vectorstores import SupabaseVectorStore
-from supabase import Client, create_client
 
 from app.config import Settings
+from app.database import supabase
 
 settings = Settings()
 
@@ -79,16 +79,6 @@ def format_docs_with_metadata(docs: list[Document]) -> tuple[str, list[dict]]:
     return '\n\n'.join([doc.page_content for doc in docs]), [doc.metadata for doc in docs]
 
 
-def get_supabase_client() -> Client:
-    """
-    Initializes and returns a Supabase client using credentials from settings.
-
-    Returns:
-        Client: An authenticated Supabase client instance.
-    """
-    return create_client(settings.SUPABASE_URL, settings.SUPABASE_ANON_KEY)
-
-
 def load_vector_db(
     embedding: Embeddings, table_name: str, query_name: str = 'match_documents'
 ) -> SupabaseVectorStore:
@@ -104,10 +94,8 @@ def load_vector_db(
     Returns:
         SupabaseVectorStore: A vector store instance connected to the specified Supabase table.
     """
-    db_client = get_supabase_client()
-
     return SupabaseVectorStore(
-        client=db_client,
+        client=supabase,
         embedding=embedding,
         table_name=table_name,
         query_name=query_name,

--- a/backend/app/routers/auth_route.py
+++ b/backend/app/routers/auth_route.py
@@ -5,10 +5,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from gotrue import AdminUserAttributes, SignUpWithPasswordCredentials
 from pydantic import BaseModel
 from sqlmodel import Session as DBSession
-from supabase import create_client
 
 from app.config import Settings
-from app.database import get_db_session
+from app.database import get_db_session, supabase
 from app.dependencies import JWTPayload, verify_jwt
 from app.models.user_profile import UserProfile
 from app.services.twilio_service import check_verification_code, send_verification_code
@@ -78,8 +77,6 @@ def create_user(req: CreateUserRequest) -> None:
         ) from e
 
     try:
-        supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_ROLE_KEY)
-
         attributes: AdminUserAttributes = {
             'email': req.email,
             'password': req.password,

--- a/backend/app/tests/services/test_user_profile_service.py
+++ b/backend/app/tests/services/test_user_profile_service.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pytest_mock import MockerFixture
+
+from app.models.user_profile import UserProfile
+from app.services.user_profile_service import UserService
+
+
+@pytest.fixture
+def mock_user() -> UserProfile:
+    return UserProfile(
+        id=uuid4(),
+        email='test@example.com',
+        account_role='user',
+    )
+
+
+@pytest.fixture
+def mock_db(mock_user: UserProfile) -> MagicMock:
+    db = MagicMock()
+    db.get.return_value = mock_user
+    return db
+
+
+@pytest.fixture
+def user_service(mock_db: MagicMock) -> UserService:
+    return UserService(db=mock_db)
+
+
+@pytest.fixture
+def mock_supabase(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch('app.services.user_profile_service.supabase')
+
+
+def test__delete_user_success(
+    user_service: UserService, mock_user: UserProfile, mock_db: MagicMock, mock_supabase: MagicMock
+) -> None:
+    user_service._delete_user(mock_user.id)
+
+    mock_db.get.assert_called_once_with(UserProfile, mock_user.id)
+    mock_db.delete.assert_called_once_with(mock_user)
+    mock_db.commit.assert_called_once()
+    mock_supabase.auth.admin.delete_user.assert_called_once_with(str(mock_user.id))
+
+
+def test__delete_user_db_commit_fails(
+    user_service: UserService,
+    mock_user: UserProfile,
+    mock_db: MagicMock,
+    mock_supabase: MagicMock,
+) -> None:
+    mock_db.commit.side_effect = Exception('DB error')
+
+    with pytest.raises(HTTPException) as exc_info:
+        user_service._delete_user(mock_user.id)
+
+    mock_db.rollback.assert_called_once()
+    mock_supabase.auth.admin.delete_user.assert_not_called()
+    assert exc_info.value.status_code == 500


### PR DESCRIPTION
Current Situation
Users were not deleted from supabase auth table.

Proposed Solution
Delete users from supabase auth table at deletion endpoint. Also added simple unit tests.

Testing
Tested via swagger with the admin mock user and the regular mock user with DEV_MODE_SKIP_AUTH=True.

Reviewer Notes
Do the same as done under testing just to double check.
