### PR TITLE
feat(F-541): Remove the pause button in the Simualtion page and clean up pause states

### DIFF
--- a/frontend/src/app/[locale]/(standalone)/simulation/[id]/components/SimulationFooter.tsx
+++ b/frontend/src/app/[locale]/(standalone)/simulation/[id]/components/SimulationFooter.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import { Pause, Play, Phone, Mic, MicOff } from 'lucide-react';
+import { Phone, Mic, MicOff } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 
 export default function SimulationFooter({
-  isPaused,
-  setIsPaused,
   isMicActive,
   toggleMicrophone,
   isConnected,
   onDisconnect,
 }: {
-  isPaused: boolean;
-  setIsPaused: (v: boolean) => void;
   isMicActive: boolean;
   toggleMicrophone: () => void;
   isConnected: boolean;
@@ -20,14 +16,6 @@ export default function SimulationFooter({
 }) {
   return (
     <div className="flex items-center justify-between md:justify-center md:gap-16 px-6 pt-4 pb-6 bg-white z-10">
-      <Button
-        size="iconLarge"
-        variant="outline"
-        onClick={() => setIsPaused(!isPaused)}
-        aria-label={isPaused ? 'Resume' : 'Pause'}
-      >
-        {isPaused ? <Play className="!w-6 !h-6" /> : <Pause className="!w-6 !h-6" />}
-      </Button>
       <Button size="iconLarge" variant="outline" onClick={toggleMicrophone}>
         {isMicActive ? <Mic className="!w-6 !h-6" /> : <MicOff className="!w-6 !h-6" />}
       </Button>

--- a/frontend/src/app/[locale]/(standalone)/simulation/[id]/components/SimulationPage.tsx
+++ b/frontend/src/app/[locale]/(standalone)/simulation/[id]/components/SimulationPage.tsx
@@ -239,7 +239,6 @@ function useOpenAIRealtimeWebRTC(sessionId: string) {
 
 export default function SimulationPageComponent({ sessionId }: SimulationPageComponentProps) {
   const [time, setTime] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
   const {
     isMicActive,
     setIsMicActive,
@@ -254,14 +253,11 @@ export default function SimulationPageComponent({ sessionId }: SimulationPageCom
   } = useOpenAIRealtimeWebRTC(sessionId);
 
   useEffect(() => {
-    if (!isPaused) {
-      const interval = setInterval(() => {
-        setTime((prev) => prev + 1);
-      }, 1000);
-      return () => clearInterval(interval);
-    }
-    return undefined;
-  }, [isPaused]);
+    const interval = setInterval(() => {
+      setTime((prev) => prev + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     initWebRTC();
@@ -295,8 +291,6 @@ export default function SimulationPageComponent({ sessionId }: SimulationPageCom
       <SimulationRealtimeSuggestions />
 
       <SimulationFooter
-        isPaused={isPaused}
-        setIsPaused={setIsPaused}
         isMicActive={isMicActive}
         toggleMicrophone={toggleMic}
         isConnected={isConnected && isDataChannelReady}


### PR DESCRIPTION


Got to **Preview** Tab ^^^ and select your template:

- [Backend PR Template](?template=backend.md)
- [Default PR Template](?template=default.md)
