### PR TITLE
feat(F-536): update POST review endpoint

### DIFF
--- a/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
+++ b/frontend/src/app/[locale]/(main)/feedback/[id]/components/FeedbackDialog.tsx
@@ -52,6 +52,7 @@ export default function ReviewDialog({ sessionId }: ReviewDialogProps) {
         rating,
         comment: ratingDescription,
         sessionId,
+        allowAdminAccess: shareWithAdmin,
       });
       showSuccessToast(t('submitReviewSuccess'));
     } catch (error) {

--- a/frontend/src/interfaces/models/Review.ts
+++ b/frontend/src/interfaces/models/Review.ts
@@ -2,6 +2,7 @@ export interface ReviewCreate {
   rating: number;
   comment: string;
   sessionId: string;
+  allowAdminAccess: boolean;
 }
 export interface Review {
   id: string;


### PR DESCRIPTION
### Proposed Solution
- Add `allowAdminAccess` property to the POST review endpoint

<img width="1536" alt="Screenshot 2025-06-30 at 19 12 47" src="https://github.com/user-attachments/assets/eb39f307-f883-4bed-b87b-c1475e8bc439" />
<img width="929" alt="Screenshot 2025-06-30 at 19 15 00" src="https://github.com/user-attachments/assets/923353f9-8fad-47e3-ba7f-a3238d20ec95" />

#### Implications
No

### Testing
1) Add a new review & make a choice for the allowAdmin checkbox
2) Check if the newly added review returns the correct bool value in the backend

### Reviewer Notes
No
