### PR TITLE
chore: Modify csp policy to allow local development

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -12,7 +12,7 @@ export default async function middleware(request: NextRequest) {
 
   const cspHeader = `
     default-src 'self';
-    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_API_URL};
+    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000'};
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' ${isDev ? 'unsafe-eval' : ''};
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;


### PR DESCRIPTION
The phone number confirmation was failing during local development due to false csp policy.
Modified the policy and tested locally.