### PR TITLE
Update fly-dev.toml to always run min 1 machine

### DIFF
--- a/backend/fly-dev.toml
+++ b/backend/fly-dev.toml
@@ -15,7 +15,7 @@ internal_port = 8000
 force_https = true
 auto_stop_machines = 'stop'
 auto_start_machines = true
-min_machines_running = 0
+min_machines_running = 1
 processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
### Current Situation
The fly dev deployment auto-stops when unused
### Proposed Solution
Run 1 machine at all times, rest - auto-stop. Same as prod deployment
