### PR TITLE
fix(M): add check for google cloud credentials

### DIFF
--- a/backend/app/connections/gcs_client.py
+++ b/backend/app/connections/gcs_client.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from app.config import Settings
+from app.services.google_cloud_storage_service import GCSManager
+
+settings = Settings()
+
+_gcs_audio_manager: Optional[GCSManager] = None
+_gcs_docs_manager: GCSManager = None
+
+
+def _is_authorized_for_gcs() -> bool:
+    return all(
+        [
+            settings.GCP_PRIVATE_KEY_ID,
+            settings.GCP_PRIVATE_KEY,
+            settings.GCP_CLIENT_EMAIL,
+            settings.GCP_CLIENT_ID,
+        ]
+    )
+
+
+def get_gcs_audio_manager() -> Optional[GCSManager]:
+    global _gcs_audio_manager
+    if _gcs_audio_manager:
+        return _gcs_audio_manager
+    elif _is_authorized_for_gcs():
+        _gcs_audio_manager = GCSManager('audio')
+        return _gcs_audio_manager
+    return None
+
+
+def get_gcs_docs_manager() -> GCSManager:
+    global _gcs_docs_manager
+    if _gcs_docs_manager:
+        return _gcs_docs_manager
+    elif _is_authorized_for_gcs():
+        _gcs_docs_manager = GCSManager('docs')
+        return _gcs_docs_manager
+    return None

--- a/backend/app/routers/signed_url_route.py
+++ b/backend/app/routers/signed_url_route.py
@@ -3,12 +3,10 @@ from http import HTTPStatus
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
+from app.connections.gcs_client import get_gcs_audio_manager, get_gcs_docs_manager
 from app.dependencies import require_user
-from app.services.google_cloud_storage_service import GCSManager
 
 router = APIRouter(prefix='/signed-url', tags=['Signed URLs'], dependencies=[Depends(require_user)])
-gcs_manager_docs = GCSManager('docs')
-gcs_manager_audio = GCSManager('audio')
 
 
 @router.get(
@@ -23,14 +21,12 @@ def get_docs_signed_url(
     filename: str = Query(..., min_length=1, description='Name of the document file'),
 ) -> dict:
     try:
-        url = gcs_manager_docs.generate_signed_url(filename)
+        gcs = get_gcs_docs_manager()
+        url = gcs.generate_signed_url(filename)
     except FileNotFoundError as file_not_found_error:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
-            detail=(
-                f"Document '{filename}' not found in bucket "
-                f"'{gcs_manager_docs.bucket_name}/{gcs_manager_docs.prefix}'"
-            ),
+            detail=(f"Document '{filename}' not found in bucket '{gcs.bucket_name}/{gcs.prefix}'"),
         ) from file_not_found_error
     except Exception as exception:
         logging.exception('Error generating signed URL for docs')
@@ -53,13 +49,13 @@ def get_audio_signed_url(
     filename: str = Query(..., min_length=1, description='Name of the audio file'),
 ) -> dict:
     try:
-        url = gcs_manager_audio.generate_signed_url(filename)
+        gcs = get_gcs_audio_manager()
+        url = gcs.generate_signed_url(filename)
     except FileNotFoundError as file_not_found_error:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
             detail=(
-                f"Audio file '{filename}' not found in bucket "
-                f"'{gcs_manager_audio.bucket_name}/{gcs_manager_audio.prefix}'"
+                f"Audio file '{filename}' not found in bucket '{gcs.bucket_name}/{gcs.prefix}'"
             ),
         ) from file_not_found_error
     except Exception as exception:

--- a/backend/app/routers/signed_url_route.py
+++ b/backend/app/routers/signed_url_route.py
@@ -7,6 +7,8 @@ from app.dependencies import require_user
 from app.services.google_cloud_storage_service import GCSManager
 
 router = APIRouter(prefix='/signed-url', tags=['Signed URLs'], dependencies=[Depends(require_user)])
+gcs_manager_docs = GCSManager('docs')
+gcs_manager_audio = GCSManager('audio')
 
 
 @router.get(
@@ -20,13 +22,15 @@ router = APIRouter(prefix='/signed-url', tags=['Signed URLs'], dependencies=[Dep
 def get_docs_signed_url(
     filename: str = Query(..., min_length=1, description='Name of the document file'),
 ) -> dict:
-    gcs = GCSManager('docs')
     try:
-        url = gcs.generate_signed_url(filename)
+        url = gcs_manager_docs.generate_signed_url(filename)
     except FileNotFoundError as file_not_found_error:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
-            detail=f"Document '{filename}' not found in bucket '{gcs.bucket_name}/{gcs.prefix}'",
+            detail=(
+                f"Document '{filename}' not found in bucket "
+                f"'{gcs_manager_docs.bucket_name}/{gcs_manager_docs.prefix}'"
+            ),
         ) from file_not_found_error
     except Exception as exception:
         logging.exception('Error generating signed URL for docs')
@@ -48,13 +52,15 @@ def get_docs_signed_url(
 def get_audio_signed_url(
     filename: str = Query(..., min_length=1, description='Name of the audio file'),
 ) -> dict:
-    gcs = GCSManager('audio')
     try:
-        url = gcs.generate_signed_url(filename)
+        url = gcs_manager_audio.generate_signed_url(filename)
     except FileNotFoundError as file_not_found_error:
         raise HTTPException(
             status_code=HTTPStatus.NOT_FOUND,
-            detail=f"Audio file '{filename}' not found in bucket '{gcs.bucket_name}/{gcs.prefix}'",
+            detail=(
+                f"Audio file '{filename}' not found in bucket "
+                f"'{gcs_manager_audio.bucket_name}/{gcs_manager_audio.prefix}'"
+            ),
         ) from file_not_found_error
     except Exception as exception:
         logging.exception('Error generating signed URL for audio')

--- a/backend/app/services/session_turn_service.py
+++ b/backend/app/services/session_turn_service.py
@@ -12,6 +12,7 @@ from app.schemas.session_turn import SessionTurnCreate, SessionTurnRead
 from app.services.google_cloud_storage_service import GCSManager
 
 settings = Settings()
+gcs = GCSManager('audio')
 
 
 def is_valid_audio_mime_type(mime_type: str) -> bool:
@@ -43,7 +44,6 @@ def get_audio_content_type(upload_file: UploadFile) -> str:
 
 def store_audio_file(session_id: UUID, audio_file: UploadFile) -> str:
     audio_name = f'{session_id}_{uuid4().hex}'
-    gcs = GCSManager('audio')
 
     try:
         gcs.upload_from_fileobj(
@@ -52,7 +52,7 @@ def store_audio_file(session_id: UUID, audio_file: UploadFile) -> str:
             content_type=get_audio_content_type(audio_file),
         )
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f'Failed to upload audio file: {str(e)}') from e
+        raise HTTPException(status_code=500, detail='Failed to upload audio file') from e
 
     return audio_name
 

--- a/backend/app/services/session_turn_service.py
+++ b/backend/app/services/session_turn_service.py
@@ -2,12 +2,16 @@ from uuid import uuid4
 
 import puremagic
 from fastapi import HTTPException, UploadFile
+from sqlalchemy import UUID
 from sqlmodel import Session as DBSession
 
+from app.config import Settings
 from app.models.session import Session as SessionModel
 from app.models.session_turn import SessionTurn
 from app.schemas.session_turn import SessionTurnCreate, SessionTurnRead
 from app.services.google_cloud_storage_service import GCSManager
+
+settings = Settings()
 
 
 def is_valid_audio_mime_type(mime_type: str) -> bool:
@@ -37,6 +41,33 @@ def get_audio_content_type(upload_file: UploadFile) -> str:
     return mime
 
 
+def store_audio_file(session_id: UUID, audio_file: UploadFile) -> str:
+    audio_name = f'{session_id}_{uuid4().hex}'
+    gcs = GCSManager('audio')
+
+    try:
+        gcs.upload_from_fileobj(
+            file_obj=audio_file.file,
+            blob_name=audio_name,
+            content_type=get_audio_content_type(audio_file),
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f'Failed to upload audio file: {str(e)}') from e
+
+    return audio_name
+
+
+def is_authorized_for_gcs() -> bool:
+    return all(
+        [
+            settings.GCP_PRIVATE_KEY_ID,
+            settings.GCP_PRIVATE_KEY,
+            settings.GCP_CLIENT_EMAIL,
+            settings.GCP_CLIENT_ID,
+        ]
+    )
+
+
 class SessionTurnService:
     def __init__(self, db: DBSession) -> None:
         self.db = db
@@ -58,25 +89,16 @@ class SessionTurnService:
         if not turn.text:
             raise HTTPException(status_code=400, detail='Text is required')
 
-        # Generate a unique audio name using session_id and new uuid
-        audio_name = f'{turn.session_id}_{uuid4().hex}'
+        audio_uri = ''
 
-        gcs = GCSManager('audio')
-
-        try:
-            gcs.upload_from_fileobj(
-                file_obj=audio_file.file,
-                blob_name=audio_name,
-                content_type=get_audio_content_type(audio_file),
-            )
-        except Exception as e:
-            raise HTTPException(
-                status_code=500, detail=f'Failed to upload audio file: {str(e)}'
-            ) from e
+        if settings.ENABLE_AI and not is_authorized_for_gcs():
+            raise HTTPException(status_code=500, detail='Audio storage is not enabled')
+        elif settings.ENABLE_AI and is_authorized_for_gcs():
+            audio_uri = store_audio_file(turn.session_id, audio_file)
 
         # Create a new SessionTurn instance
         turn_data = turn.model_dump()
-        turn_data['audio_uri'] = audio_name
+        turn_data['audio_uri'] = audio_uri
         new_turn = SessionTurn(**turn_data)
 
         self.db.add(new_turn)
@@ -90,7 +112,7 @@ class SessionTurnService:
             start_offset_ms=new_turn.start_offset_ms,
             end_offset_ms=new_turn.end_offset_ms,
             text=new_turn.text,
-            audio_uri=audio_name,
+            audio_uri=audio_uri,
             ai_emotion=new_turn.ai_emotion,
             created_at=new_turn.created_at,
         )


### PR DESCRIPTION
# Add check for gcs credentials on session turn post
### Current Situation
No checks have been made if gcs credentials are set, before trying to store audio recordings to the google cloud storage.
### Proposed Solution
Add a check if the required environment variables are set if ENABLE_AI=True
#### Implications
None.
### Testing
Test with different environment configs to test all cases. Talk to AI on Simulation Page to trigger session turn posts.
### Reviewer Notes
Double checking code should be sufficient.
