### PR TITLE
feat(M): Added licensing and removed source from vectordb metadata

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
     GCP_PRIVATE_KEY: str = ''
     GCP_CLIENT_EMAIL: str = ''
     GCP_CLIENT_ID: str = ''
-    GCP_BUCKET: str = 'coachai'
+    GCP_BUCKET: str = 'coachai-dev'
     GCP_PROJECT_ID: str = 'personio-foundation'
 
     @property

--- a/backend/app/rag/document-licenses.json
+++ b/backend/app/rag/document-licenses.json
@@ -1,0 +1,8 @@
+{
+  "A Guide to Effective Negotiations.pdf": "CC BY-NC-SA 4.0",
+  "Communication at Work.pdf": "CC BY 4.0",
+  "Giving Feedback.pdf": "CC BY-NC 4.0",
+  "HR Management.pdf": "CC BY-NC-SA 3.0",
+  "Psychology of Human Relations.pdf": "CC BY-NC-SA",
+  "Teamwork: An Open Access Practical Guide.pdf": "CC BY-NC-SA"
+}

--- a/backend/app/rag/vector_db.py
+++ b/backend/app/rag/vector_db.py
@@ -1,4 +1,6 @@
+import json
 import os
+from pathlib import Path
 
 from langchain.embeddings.base import Embeddings
 from langchain.schema import Document
@@ -35,16 +37,35 @@ def prepare_vector_db_docs(doc_folder: str) -> list[Document]:
     if not os.path.isdir(doc_folder):
         print(f"Warning: Document folder '{doc_folder}' does not exist.")
         return []
+
+    license_map = load_license_mapping()
     for file in os.listdir(doc_folder):
         if file.endswith('.pdf'):
             file_path = os.path.join(doc_folder, file)
             try:
                 loader = PyPDFLoader(file_path)
-                doc = loader.load()
-                splits = text_splitter.split_documents(doc)
+                loaded_docs = loader.load()
+
+                doc_name = os.path.basename(file)
+                license_name = license_map.get(doc_name, 'Unknown')
+
+                if license_name == 'Unknown':
+                    print(f"⚠️ No license found for '{doc_name}', defaulting to 'Unknown'.")
+                else:
+                    print(f"📄 '{doc_name}' assigned license: {license_name}")
+
+                for doc in loaded_docs:
+                    # Replacing null bytes as they lead to errors
+                    doc.page_content = doc.page_content.replace('\u0000', '')
+                    doc.metadata['licenseName'] = license_name
+                    doc.metadata.pop('source', None)
+
+                splits = text_splitter.split_documents(loaded_docs)
                 docs.extend(splits)
             except Exception as e:
-                print(f'Error loading or splitting PDF {file_path}: {e}')
+                print(f'❌ Error processing {file_path}: {e}')
+
+    print(f'✅ Prepared {len(docs)} document chunks for vector DB.')
     return docs
 
 
@@ -100,3 +121,13 @@ def load_vector_db(
         table_name=table_name,
         query_name=query_name,
     )
+
+
+def load_license_mapping(
+    file_path: Path = Path(__file__).parent / 'document-licenses.json',
+) -> dict:
+    """
+    Loads a mapping from document filename to license name from a JSON file.
+    """
+    with open(file_path) as f:
+        return json.load(f)


### PR DESCRIPTION
Closes #620.
Just a small change that changes the document metadata in the vector store:
- Removed source
- Just the document name (which we need remains)
- Added custom licensing

Also defaulted the bucket to coachai-dev so that no one accidentally modifies the prod bucket.

Tested in on local supabase with a short test script (not commited, as document uploading will change again soon):

```python
import os

from app.rag.embeddings import get_embedding_model
from app.rag.rag import DOC_FOLDER, EMBEDDING_TYPE, TABLE_NAME
from app.rag.vector_db import load_vector_db, prepare_vector_db_docs


def upload_documents_to_supabase() -> None:
    print("🔄 Starting document upload to Supabase vector DB...")

    embedding = get_embedding_model(EMBEDDING_TYPE)

    vector_db = load_vector_db(embedding, TABLE_NAME)

    os.makedirs(DOC_FOLDER, exist_ok=True)
    docs = prepare_vector_db_docs(str(DOC_FOLDER))

    if not docs:
        print(f"⚠️ No valid documents found in folder: {DOC_FOLDER}")
        return

    vector_db.add_documents(docs)
    print(f"✅ Successfully uploaded {len(docs)} documents to table '{TABLE_NAME}'")

if __name__ == '__main__':
    upload_documents_to_supabase()
```

Please look at your hr_information table in supabase and check if the metadata has a license name, a title, but no path.