### PR TITLE
Remove unused ConversationScenarioStatus from Conversation Scenario

### DIFF
--- a/backend/app/schemas/conversation_scenario.py
+++ b/backend/app/schemas/conversation_scenario.py
@@ -3,7 +3,6 @@ from uuid import UUID
 from app.models.camel_case import CamelModel
 from app.models.conversation_scenario import (
     ConversationScenario,
-    ConversationScenarioStatus,
     DifficultyLevel,
 )
 from app.models.language import LanguageCode
@@ -18,7 +17,6 @@ class ConversationScenarioCreate(CamelModel):
     situational_facts: str
     difficulty_level: DifficultyLevel
     language_code: LanguageCode = LanguageCode.en
-    status: ConversationScenarioStatus = ConversationScenarioStatus.draft
 
 
 class ConversationScenarioCreateResponse(CamelModel):


### PR DESCRIPTION
Remove unused ConversationScenarioStatus from Conversation Scenario

## 🔍 Current Situation

No issue. Optional parameter lead to confusion.

## ✅ Local Testing Instructions

Tested in swagger ui

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [x] I confirmed that all new or changed **environment variables** are:icated to other stakeholders (if needed).

- [x] All migrations or DB changes have been tested locally.
- [x] I added or updated relevant unit/integration tests.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

