### PR TITLE
feat(M): made admin as default user

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,7 +14,7 @@ SUPABASE_JWT_SECRET=
 CORS_ORIGIN=  # leave empty for local development, it defaults to http://localhost:3000
 
 DEV_MODE_SKIP_AUTH=true
-DEV_MODE_MOCK_USER_ID=
+DEV_MODE_MOCK_ADMIN_ID= # Not needed by default
 
 #-----------------
 # This Variables are ONLY needed for twilio_service.py .

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     FORCE_CHEAP_MODEL: bool = True
 
     DEV_MODE_SKIP_AUTH: bool = True
-    DEV_MODE_MOCK_USER_ID: UUID = MockUserIdsEnum.USER.value
+    DEV_MODE_MOCK_ADMIN_ID: UUID = MockUserIdsEnum.ADMIN.value
 
     DEMO_USER_EMAIL: str = 'mockuser@example.com'
     DEMO_USER_PASSWORD: str = 'mockuserpassword'

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -40,7 +40,7 @@ def verify_jwt(
     """
     if settings.stage == 'dev' and settings.DEV_MODE_SKIP_AUTH:
         logging.info('Skipping JWT verification')
-        return JWTPayload(sub=str(settings.DEV_MODE_MOCK_USER_ID))
+        return JWTPayload(sub=str(settings.DEV_MODE_MOCK_ADMIN_ID))
     logging.info('Verifying JWT')
     if not credentials:
         logging.info('No JWT token')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     environment:
       STAGE: dev
       DEV_MODE_SKIP_AUTH: ${DEV_MODE_SKIP_AUTH:-True}
-      DEV_MODE_MOCK_USER_ID: ${DEV_MODE_MOCK_USER_ID:-763c76f3-e5a4-479c-8b53-e3418d5e2ef5}
+      DEV_MODE_MOCK_ADMIN_ID: ${DEV_MODE_MOCK_ADMIN_ID:-763c76f3-e5a4-479c-8b53-e3418d5e2ef5}
       DATABASE_URL: postgresql://postgres:postgres@host.docker.internal:54322/postgres
       POSTGRES_HOST: host.docker.internal
       POSTGRES_PORT: 54322


### PR DESCRIPTION
Made admin the default user. Just log out or delete your cookies and run the local setup again. Now you should be logged in as admin, not user.

The rason: Admin has a superset of user functionality and it enables the frontend to test out admin functionality without changing the config.