### PR TITLE
refactor(B-678): consistent naming reviews endpoint and schemas

### DIFF
--- a/backend/app/routers/review_route.py
+++ b/backend/app/routers/review_route.py
@@ -8,9 +8,9 @@ from app.dependencies import require_admin, require_user
 from app.models.user_profile import UserProfile
 from app.schemas.review import (
     PaginatedReviewRead,
+    ReviewConfirm,
     ReviewCreate,
     ReviewRead,
-    ReviewResponse,
 )
 from app.services.review_service import ReviewService
 
@@ -39,12 +39,12 @@ def get_reviews(
     return service.get_reviews(limit, page, page_size, sort)
 
 
-@router.post('', response_model=ReviewResponse)
+@router.post('', response_model=ReviewConfirm)
 def create_review(
     review: ReviewCreate,
     user_profile: Annotated[UserProfile, Depends(require_user)],
     service: Annotated[ReviewService, Depends(get_review_service)],
-) -> ReviewResponse:
+) -> ReviewConfirm:
     """
     Create a new review.
     """

--- a/backend/app/routers/review_route.py
+++ b/backend/app/routers/review_route.py
@@ -7,7 +7,7 @@ from app.database import get_db_session
 from app.dependencies import require_admin, require_user
 from app.models.user_profile import UserProfile
 from app.schemas.review import (
-    PaginatedReviewsResponse,
+    PaginatedReviewRead,
     ReviewCreate,
     ReviewRead,
     ReviewResponse,
@@ -23,7 +23,7 @@ def get_review_service(db: Annotated[DBSession, Depends(get_db_session)]) -> Rev
 
 @router.get(
     '',
-    response_model=list[ReviewRead] | PaginatedReviewsResponse,
+    response_model=list[ReviewRead] | PaginatedReviewRead,
     dependencies=[Depends(require_admin)],
 )
 def get_reviews(
@@ -32,7 +32,7 @@ def get_reviews(
     page: int | None = Query(None),
     page_size: int = Query(10),
     sort: str = Query('newest'),
-) -> list[ReviewRead] | PaginatedReviewsResponse:
+) -> list[ReviewRead] | PaginatedReviewRead:
     """
     Retrieve user reviews with optional pagination, statistics and sorting.
     """

--- a/backend/app/routers/review_route.py
+++ b/backend/app/routers/review_route.py
@@ -14,7 +14,7 @@ from app.schemas.review import (
 )
 from app.services.review_service import ReviewService
 
-router = APIRouter(prefix='/review', tags=['User Review'])
+router = APIRouter(prefix='/reviews', tags=['User Review'])
 
 
 def get_review_service(db: Annotated[DBSession, Depends(get_db_session)]) -> ReviewService:

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -4,7 +4,7 @@ from app.schemas.conversation_category import ConversationCategoryRead
 from app.schemas.conversation_scenario import ConversationScenarioCreate
 from app.schemas.message_schema import MessageCreateSchema, MessageSchema
 from app.schemas.review import (
-    PaginatedReviewsResponse,
+    PaginatedReviewRead,
     ReviewCreate,
     ReviewRead,
     ReviewResponse,
@@ -75,7 +75,7 @@ __all__ = [
     'ReviewRead',
     'ReviewResponse',
     'ReviewStatistics',
-    'PaginatedReviewsResponse',
+    'PaginatedReviewRead',
     'ChecklistRequest',
     'ConversationScenarioBase',
     'KeyConcept',

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -5,9 +5,9 @@ from app.schemas.conversation_scenario import ConversationScenarioCreate
 from app.schemas.message_schema import MessageCreateSchema, MessageSchema
 from app.schemas.review import (
     PaginatedReviewRead,
+    ReviewConfirm,
     ReviewCreate,
     ReviewRead,
-    ReviewResponse,
     ReviewStatistics,
 )
 from app.schemas.scenario_preparation import (
@@ -73,7 +73,7 @@ __all__ = [
     'ConversationScenarioCreate',
     'ReviewCreate',
     'ReviewRead',
-    'ReviewResponse',
+    'ReviewConfirm',
     'ReviewStatistics',
     'PaginatedReviewRead',
     'ChecklistRequest',

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -38,7 +38,7 @@ class ReviewStatistics(CamelModel):
     num_one_star: int
 
 
-class PaginatedReviewsResponse(CamelModel):
+class PaginatedReviewRead(CamelModel):
     reviews: list[ReviewRead]
     pagination: dict
     rating_statistics: ReviewStatistics

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -12,7 +12,7 @@ class ReviewCreate(CamelModel):
     allow_admin_access: bool = False  # admin access to session details
 
 
-class ReviewResponse(CamelModel):
+class ReviewConfirm(CamelModel):
     message: str = 'Review submitted successfully'
     review_id: UUID
 

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -13,9 +13,9 @@ from app.models.session import Session
 from app.models.user_profile import AccountRole, UserProfile
 from app.schemas.review import (
     PaginatedReviewRead,
+    ReviewConfirm,
     ReviewCreate,
     ReviewRead,
-    ReviewResponse,
     ReviewStatistics,
 )
 
@@ -207,7 +207,7 @@ class ReviewService:
         self,
         review: ReviewCreate,
         user_profile: UserProfile,
-    ) -> ReviewResponse:
+    ) -> ReviewConfirm:
         """
         Create a new review.
         """
@@ -246,7 +246,7 @@ class ReviewService:
                 self.db.commit()
                 self.db.refresh(session)
 
-        return ReviewResponse(
+        return ReviewConfirm(
             message='Review submitted successfully',
             review_id=new_review.id,
         )

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -12,7 +12,7 @@ from app.models.review import Review
 from app.models.session import Session
 from app.models.user_profile import AccountRole, UserProfile
 from app.schemas.review import (
-    PaginatedReviewsResponse,
+    PaginatedReviewRead,
     ReviewCreate,
     ReviewRead,
     ReviewResponse,
@@ -101,13 +101,13 @@ class ReviewService:
         page: int | None = Query(None),
         page_size: int = Query(10),
         sort: str = Query('newest'),
-    ) -> PaginatedReviewsResponse:
+    ) -> PaginatedReviewRead:
         """Retrieve paginated reviews with optional sorting."""
 
         # Pagination
         total_count = self.db.exec(select(func.count()).select_from(Review)).one()
         if total_count == 0:
-            return PaginatedReviewsResponse(
+            return PaginatedReviewRead(
                 reviews=[],
                 pagination={
                     'currentPage': page if page else 1,
@@ -135,7 +135,7 @@ class ReviewService:
 
         review_statistics = self._get_review_statistics()
 
-        return PaginatedReviewsResponse(
+        return PaginatedReviewRead(
             reviews=review_list,
             pagination={
                 'currentPage': page if page else 1,
@@ -152,7 +152,7 @@ class ReviewService:
         page: int | None = Query(None),
         page_size: int = Query(10),
         sort: str = Query('newest'),
-    ) -> list[ReviewRead] | PaginatedReviewsResponse:
+    ) -> list[ReviewRead] | PaginatedReviewRead:
         """
         Retrieve user reviews with optional pagination, statistics and sorting.
         """

--- a/backend/app/tests/routers/test_review_router.py
+++ b/backend/app/tests/routers/test_review_router.py
@@ -86,15 +86,15 @@ class TestReviewRoute(unittest.TestCase):
             'allowAdminAccess': False,
         }
         # Test invalid rating
-        response = self.client.post('/review', json=review_payload)
+        response = self.client.post('/reviews', json=review_payload)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['detail'], 'Rating must be between 1 and 5')
 
         # Test valid review
         review_payload['rating'] = 5
-        response = self.client.post('/review', json=review_payload)
+        response = self.client.post('/reviews', json=review_payload)
         self.assertEqual(response.status_code, 200)
 
         # Test duplicate review
-        response = self.client.post('/review', json=review_payload)
+        response = self.client.post('/reviews', json=review_payload)
         self.assertEqual(response.status_code, 409)

--- a/frontend/src/services/ReviewService.ts
+++ b/frontend/src/services/ReviewService.ts
@@ -8,7 +8,7 @@ const getPaginatedReviews = async (
   sort: string = 'newest'
 ) => {
   try {
-    const { data } = await api.get(`/review`, {
+    const { data } = await api.get(`/reviews`, {
       params: {
         page,
         page_size: pageSize,
@@ -24,7 +24,7 @@ const getPaginatedReviews = async (
 
 const createReview = async (api: AxiosInstance, review: ReviewCreate) => {
   try {
-    const { data } = await api.post('/review', review);
+    const { data } = await api.post('/reviews', review);
     return data;
   } catch (error) {
     console.error('Error creating review:', error);


### PR DESCRIPTION
## 🔍 Current Situation
Closes: #678 

## 💡 Proposed Solution

- changed /review endpoint to /reviews endpoint
- renamed some review schemas to align with consistent naming

## 🚨 Implications

- Does this affect any APIs (add/remove/change endpoints)?
- Do other systems or teams depend on this behavior?
- Is there another PR (frontend or backend) that must be merged first?
- Did you deprecate/remove any feature or behavior?

## ✅ Local Testing Instructions

test /reviews endpoints

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [x] All migrations or DB changes have been tested locally.
- [x] I added or updated relevant unit/integration tests.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes

- Which parts of the code need extra attention?
- Is this a functional change, a refactor, or a cleanup?
- Any known issues or follow-up work?
