### PR TITLE
Fix require_user/admin logging causing errors

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import UTC, datetime
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, NoReturn, TypedDict
 
 import jwt
 from fastapi import Depends, HTTPException, status
@@ -31,6 +31,15 @@ class JWTPayload(TypedDict, total=False):
     amr: list[Any]
     session_id: str
     is_anonymous: bool
+
+
+ALLOWED_ROLES = {AccountRole.user.value, AccountRole.admin.value}
+
+
+def _forbidden(detail: str, log_msg: str, *args: str) -> NoReturn:
+    """Log a warning and raise a 403 HttpException."""
+    logging.warning(log_msg, *args)
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
 
 def verify_jwt(
@@ -77,20 +86,25 @@ def require_user(
     db: Annotated[Session, Depends(get_db_session)],
 ) -> UserProfile:
     """
-    Checks if the user is authenticated and has the role of 'user' or 'admin'.
+    Checks that the JWT has a 'sub', that a UserProfile exists for it,
+    and that its role is either 'user' or 'admin'.
     """
-    user_id = token['sub']
-    statement = select(UserProfile).where(UserProfile.id == user_id)
-    user = db.exec(statement).first()
-    if not user:
-        logging.warning('User not found for ID: ', user_id)
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Cannot find user')
-    if user.account_role not in [AccountRole.user, AccountRole.admin]:
-        logging.warning('User role is not one of: ', AccountRole.user, AccountRole.admin)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail='User does not have access'
+    user_id = token.get('sub') or _forbidden('Cannot find user', 'JWT payload missing "sub" claim')
+
+    user = db.exec(select(UserProfile).where(UserProfile.id == user_id)).first() or _forbidden(
+        'Cannot find user', 'User not found for ID %s', user_id
+    )
+
+    if user.account_role.value not in ALLOWED_ROLES:
+        _forbidden(
+            'User does not have access',
+            'User role %s not in allowed roles %s',
+            user.account_role,
+            *ALLOWED_ROLES,
         )
+
     _update_login_streak(db, user)
+
     return user
 
 
@@ -99,18 +113,19 @@ def require_admin(
     db: Annotated[Session, Depends(get_db_session)],
 ) -> UserProfile:
     """
-    Checks if the user is authenticated and has the role of 'admin'.
+    Ensures the JWT has a 'sub' claim, the user exists, and is an admin.
     """
-    user_id = token['sub']
-    statement = select(UserProfile).where(UserProfile.id == user_id)
-    user = db.exec(statement).first()
-    if not user:
-        logging.warning('User not found for ID: ', user_id)
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Cannot find user')
-    if user.account_role != AccountRole.admin:
-        logging.warning('User role is not: ', AccountRole.admin)
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Admin access required')
+    user_id = token.get('sub') or _forbidden('Cannot find user', 'JWT payload missing "sub" claim')
+
+    user = db.exec(select(UserProfile).where(UserProfile.id == user_id)).first() or _forbidden(
+        'Cannot find user', 'User not found for ID %s', user_id
+    )
+
+    if user.account_role is not AccountRole.admin:
+        _forbidden('Admin access required', 'User role %s is not admin', user.account_role.value)
+
     _update_login_streak(db, user)
+
     return user
 
 


### PR DESCRIPTION
## 🔍 Current Situation

E.g. 
```py 
logging.warning('User role is not one of: ', AccountRole.user, AccountRole.admin)
```
is not the correct use of logging and caused an error. 

## 💡 Proposed Solution

Instead: 
```py
logging.warning('User not found for ID %s', user_id)
```

Also did some general refactoring to improve this.

## ✅ Local Testing Instructions

Pytests + Swagger + Manual testing

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [x] All migrations or DB changes have been tested locally.
- [x] I added or updated relevant unit/integration tests.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes

Nothing particular.
