### PR TITLE
fix(M): fix realtime-sessions

### DIFF
--- a/backend/app/routers/realtime_session_route.py
+++ b/backend/app/routers/realtime_session_route.py
@@ -26,7 +26,7 @@ else:
 async def get_realtime_session(
     db_session: Annotated[DBSession, Depends(get_db_session)],
     user_profile: Annotated[UserProfile, Depends(require_user)],
-    session_id: UUID,
+    id: UUID,
 ) -> dict:
     """
     Proxies a POST request to OpenAI's realtime sessions endpoint
@@ -38,7 +38,7 @@ async def get_realtime_session(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail='OPENAI_API_KEY not set'
         )
 
-    session = db_session.exec(select(Session).where(Session.id == session_id)).first()
+    session = db_session.exec(select(Session).where(Session.id == id)).first()
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Session not found')
     if session.status is SessionStatus.completed:


### PR DESCRIPTION
## 🔍 Current Situation

- /realtime-sessions endpoint is failing because of something missed while renaming

## 💡 Proposed Solution

- fixed it

## 🚨 Implications

- Does this affect any APIs (add/remove/change endpoints)?
- Do other systems or teams depend on this behavior?
- Is there another PR (frontend or backend) that must be merged first?
- Did you deprecate/remove any feature or behavior?

## ✅ Local Testing Instructions

- test GET
[/realtime-sessions/{id}](http://localhost:8000/docs#/realtime-session/get_realtime_session_realtime_sessions__id__get)

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [x] I tested the app locally using `uv run fastapi dev` or equivalent.
- [x] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [x] All migrations or DB changes have been tested locally.
- [x] I added or updated relevant unit/integration tests.
- [x] I included clear **testing instructions** in this PR.
- [x] I have considered performance, logging, and error handling.

## 🧠 Reviewer Notes

- Which parts of the code need extra attention?
- Is this a functional change, a refactor, or a cleanup?
- Any known issues or follow-up work?
