### PR TITLE
Add Session Length to GET /sessions

### DIFF
--- a/backend/app/schemas/sessions_paginated.py
+++ b/backend/app/schemas/sessions_paginated.py
@@ -20,6 +20,7 @@ class SessionItem(CamelModel):
     overall_score: float
     skills: SkillScores
     status: SessionStatus
+    session_length_s: int = 0
     allow_admin_access: bool = False
 
 

--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -534,6 +534,9 @@ class SessionService:
             overall_score=feedback.overall_score if feedback else -1,
             skills=scores,
             allow_admin_access=sess.allow_admin_access,
+            session_length_s=feedback.session_length_s
+            if feedback and feedback.session_length_s
+            else 0,
         )
 
     def _validate_scenario_access(


### PR DESCRIPTION
Include session length in seconds in paginated session response:

```json
{
  "page": 1,
  "limit": 10,
  "totalPages": 1,
  "totalSessions": 5,
  "sessions": [
    {
      "sessionId": "8cd01d09-34c1-4dc6-87bf-7ca88569b425",
      "title": "Salary Discussions",
      "summary": "Salary Discussions",
      "date": "2025-07-14T14:59:20.199733",
      "overallScore": 3.8,
      "skills": {
        "structure": 4,
        "empathy": 3,
        "focus": 4,
        "clarity": 4
      },
      "status": "completed",
      "allowAdminAccess": false,
      "sessionLengthS": 123
    }
  ]
}
```
