### PR TITLE
fix(M): call realtime session api only once on the server side

### DIFF
--- a/frontend/src/app/[locale]/(standalone)/session/[id]/components/SessionPage.tsx
+++ b/frontend/src/app/[locale]/(standalone)/session/[id]/components/SessionPage.tsx
@@ -18,6 +18,7 @@ type SessionPageComponentProps = {
   personaName: string;
   categoryName: string;
   sessionId: string;
+  ephemeralKey: string;
 };
 
 const DISCONNECTED_STATES = [
@@ -37,6 +38,7 @@ export default function SessionPageComponent({
   personaName,
   categoryName,
   sessionId,
+  ephemeralKey,
 }: SessionPageComponentProps) {
   const t = useTranslations('Session');
   const tCommon = useTranslations('Common');
@@ -54,14 +56,14 @@ export default function SessionPageComponent({
     toggleMic,
     cleanup,
     sessionLiveFeedbacks,
-  } = useWebRTC(sessionId);
+  } = useWebRTC(sessionId, ephemeralKey);
 
   useEffect(() => {
     initWebRTC();
     return () => {
       cleanup();
     };
-  }, [initWebRTC, sessionId, cleanup]);
+  }, [initWebRTC, cleanup]);
 
   const onDisconnect = async () => {
     try {

--- a/frontend/src/app/[locale]/(standalone)/session/[id]/hooks/useWebRTC.ts
+++ b/frontend/src/app/[locale]/(standalone)/session/[id]/hooks/useWebRTC.ts
@@ -1,7 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { sessionService } from '@/services/SessionService';
 import { ConnectionStatus, MessageSender } from '@/interfaces/models/Session';
-import { api } from '@/services/ApiClient';
 import { showErrorToast } from '@/lib/utils/toast';
 import { useTranslations } from 'next-intl';
 import { useMessageReducer } from './useMessageReducer';
@@ -12,7 +11,7 @@ import { useRemoteAudioRecorder } from './useRemoteAudioRecorder';
 import { useSessionTurns } from './useSessionTurns';
 import { useSessionLiveFeedback } from './useSessionLiveFeedback';
 
-export function useWebRTC(sessionId: string) {
+export function useWebRTC(sessionId: string, ephemeralKey: string) {
   const t = useTranslations('Session');
 
   const { localStreamRef, startStream, stopStream, isMicActive, toggleMic } = useMediaStream();
@@ -198,8 +197,7 @@ export function useWebRTC(sessionId: string) {
 
     try {
       const sdpText = await sessionService.getSdpResponseTextFromRealtimeApi(
-        api,
-        sessionId,
+        ephemeralKey,
         offer.sdp
       );
       await pc.setRemoteDescription({ type: 'answer', sdp: sdpText });
@@ -225,6 +223,7 @@ export function useWebRTC(sessionId: string) {
     cleanup,
     startGetLiveFeedbackInterval,
     t,
+    ephemeralKey,
   ]);
 
   return {

--- a/frontend/src/app/[locale]/(standalone)/session/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(standalone)/session/[id]/page.tsx
@@ -20,6 +20,7 @@ export default async function SessionPage(props: PagesProps) {
       sessionId={id}
       personaName={sessionRealtime.data.persona_name}
       categoryName={sessionRealtime.data.category_name}
+      ephemeralKey={sessionRealtime.data.client_secret.value}
     />
   );
 }

--- a/frontend/src/services/SessionService.ts
+++ b/frontend/src/services/SessionService.ts
@@ -79,14 +79,10 @@ const getSessionRealtime = async (api: AxiosInstance, sessionId: string) => {
 };
 
 const getSdpResponseTextFromRealtimeApi = async (
-  api: AxiosInstance,
-  sessionId: string,
+  ephemeralKey: string,
   offerSdp: string | undefined
 ) => {
   try {
-    const realtimeSessionResponse = await api.get(`/realtime-sessions/${sessionId}`);
-    const ephemeralKey = realtimeSessionResponse.data.client_secret.value;
-
     const baseUrl = 'https://api.openai.com/v1/realtime';
     const modelId = 'gpt-4o-realtime-preview-2025-06-03';
 


### PR DESCRIPTION
### Current Situation
/realtime-sessions was called twice. Once on the server side during server side rendering and once on the client side for creating the webrtc connection. This led to incrementing the session creation counter two times per rendering of the SessionPage.
### Proposed Solution
The quick fix is to pass the ephimeral_key which is required for creating the webrtc connection from the /realtime-sessions call issued on the server as a prop to the SessionPage component. Then the client can use that key to create the webrtc connection, without having to call /realtime-sessions again.

For long term, we should split up the logic in the /realtime-sessions endpoint into two separate ones. One for the metadata fetching (conversation category, persona name) which can be done on the server side, and another for checking the session limit per day, fetching the ephimeral_key from open ai, which the user calls from the client side.
#### Implications
None.
### Testing
Check the sessions_created_today counter in the user_profile table. Create a new conversation scenario and start the training. Check the sessions_created_today counter again in the user_profile table, should be +1.
### Reviewer Notes
Same as under testing for double checking.
Check my comments in the proposed solution for long term.