### PR TITLE
Fix GET /conversation-scenario - No sessions and Admin seeing all scenarios

### DIFF
--- a/backend/app/services/conversation_scenario_service.py
+++ b/backend/app/services/conversation_scenario_service.py
@@ -178,30 +178,24 @@ class ConversationScenarioService:
                 func.max(Session.started_at).label('last_session_at'),
             )
             # scenario → category (may be NULL)
-            .outerjoin(
+            .join(
                 ConversationCategory,
                 ConversationScenario.category_id == ConversationCategory.id,
             )
             # scenario → session  (may be zero)
-            .outerjoin(Session, Session.scenario_id == ConversationScenario.id)
+            .join(Session, Session.scenario_id == ConversationScenario.id, isouter=True)
             # session  → feedback (may be zero)
-            .outerjoin(SessionFeedback, SessionFeedback.session_id == Session.id)
-            .where(
-                SessionFeedback.status == FeedbackStatus.completed,
-            )
+            .join(SessionFeedback, SessionFeedback.session_id == Session.id, isouter=True)
             .group_by(
                 ConversationScenario.id,
                 ConversationScenario.language_code,
                 ConversationCategory.name,
                 ConversationScenario.custom_category_label,
             )
-            .order_by(func.max(Session.started_at).desc())  # Order by latest session start date
+            .order_by(func.max(Session.started_at).desc())
         )
 
-        if user_profile.account_role != AccountRole.admin:
-            stmt = stmt.where(ConversationScenario.user_id == user_profile.id)
-
-        # stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+        stmt = stmt.where(ConversationScenario.user_id == user_profile.id)
 
         rows = self.db.exec(stmt).all()
         scenario_count = len(rows)


### PR DESCRIPTION
Fixes:
- When a conversation scenario  has no session it was not returned. Now the session is return with session = 0
- Admins were returned all scenarios for all users. Now they can only see their own scenarios.