### PR TITLE
Feat/remove signed uri whenstoring failed

### DIFF
--- a/backend/app/services/session_feedback/session_feedback_service.py
+++ b/backend/app/services/session_feedback/session_feedback_service.py
@@ -176,6 +176,7 @@ def generate_feedback_components(
             scores_json = {}
             overall_score = 0.0
 
+        audio_signed_url = None
         try:
             stitch_result = future_audio_stitch.result()
             if stitch_result and stitch_result.output_filename:
@@ -184,6 +185,7 @@ def generate_feedback_components(
                     try:
                         audio_signed_url = gcs.generate_signed_url(stitch_result.output_filename)
                     except Exception as e:
+                        has_error = True
                         logging.warning(f'Failed to generate signed url for audio: {e}')
         except Exception as e:
             has_error = True

--- a/backend/app/tests/services/test_session_feedback_service.py
+++ b/backend/app/tests/services/test_session_feedback_service.py
@@ -97,6 +97,7 @@ class TestSessionFeedbackService(unittest.TestCase):
 
     @patch('app.services.session_feedback.session_feedback_service.get_hr_docs_context')
     @patch('app.services.session_feedback.session_feedback_service.get_conversation_data')
+    @patch('app.services.session_feedback.session_feedback_service.get_gcs_audio_manager')
     @patch('app.services.session_feedback.session_feedback_llm.generate_training_examples')
     @patch('app.services.session_feedback.session_feedback_llm.get_achieved_goals')
     @patch('app.services.session_feedback.session_feedback_llm.generate_recommendations')
@@ -105,9 +106,14 @@ class TestSessionFeedbackService(unittest.TestCase):
         mock_recommendations: MagicMock,
         mock_goals: MagicMock,
         mock_examples: MagicMock,
+        mock_get_gcs_audio_manager: MagicMock,
         mock_get_conversation_data: MagicMock,
         mock_get_hr_docs_context: MagicMock,
     ) -> None:
+        mock_gcs = MagicMock()
+        mock_gcs.generate_signed_url.return_value = 'https://mock.audio/signed_url.mp3'
+        mock_get_gcs_audio_manager.return_value = mock_gcs
+
         mock_get_conversation_data.return_value = self._mock_conversation_data()
         mock_examples.return_value = SessionExamplesRead(
             positive_examples=[

--- a/backend/app/tests/services/test_session_feedback_service.py
+++ b/backend/app/tests/services/test_session_feedback_service.py
@@ -250,15 +250,21 @@ class TestSessionFeedbackService(unittest.TestCase):
 
     @patch('app.services.session_feedback.session_feedback_service.get_conversation_data')
     @patch('app.services.session_feedback.session_feedback_llm.generate_training_examples')
+    @patch('app.services.session_feedback.session_feedback_service.get_gcs_audio_manager')
     @patch('app.services.session_feedback.session_feedback_llm.get_achieved_goals')
     @patch('app.services.session_feedback.session_feedback_llm.generate_recommendations')
     def test_generate_and_store_feedback_with_errors(
         self,
         mock_recommendations: MagicMock,
         mock_goals: MagicMock,
+        mock_get_gcs_audio_manager: MagicMock,
         mock_examples: MagicMock,
         mock_get_conversation_data: MagicMock,
     ) -> None:
+        mock_gcs = MagicMock()
+        mock_gcs.generate_signed_url.return_value = 'https://mock.audio/signed_url.mp3'
+        mock_get_gcs_audio_manager.return_value = mock_gcs
+
         mock_get_conversation_data.return_value = self._mock_conversation_data()
         mock_examples.side_effect = Exception('Failed to generate examples')
 


### PR DESCRIPTION
Closes #762
## 🔍 Current Situation

Before the case of uploading stitched  audio file with failure is not handled

## 💡 Proposed Solution

add the default file name None, so if failed -> in DB is None for this field and also the has_error is True is this case

## ✅ Local Testing Instructions

Directly try the test ‘test_generate_feedback_no_audio_url_when_store_audio_fails’ within TestSessionFeedbackService

## 🔬 Developer Checklist (must complete before marking PR as **Ready for Review**)

> Keep the PR as a **draft** until all of the following are checked and you're confident it's ready for review.

- [X] I tested the app locally using `uv run fastapi dev` or equivalent.
- [X] I ran `docker compose down -v` to removing all volumes and then `docker compose up --build` to build and start the app.
- [X] I confirmed that all new or changed **environment variables** are:

  - [ ] The app has been tested with the new environment variables removed (e.g. deleted from .env, app started in a fresh terminal).
  - [ ] Documented clearly in `.env.example` or a config file.
  - [ ] Defaulted sensibly (or fail-fast if truly required).
  - [ ] Communicated to other stakeholders (if needed).

- [X] All migrations or DB changes have been tested locally.
- [X] I added or updated relevant unit/integration tests.
- [X] I included clear **testing instructions** in this PR.
- [ ] I have considered performance, logging, and error handling.

