### PR TITLE
Update populate static data script

### DIFF
--- a/backend/app/data/populate_dummy_data.py
+++ b/backend/app/data/populate_dummy_data.py
@@ -5,7 +5,6 @@ from sqlmodel import SQLModel, text
 
 from app.data import (
     get_dummy_admin_stats,
-    get_dummy_app_configs,
     get_dummy_conversation_categories,
     get_dummy_conversation_scenarios,
     get_dummy_live_feedback_data,
@@ -94,9 +93,6 @@ def populate_data() -> None:
         # Populate User Confidence Scores
         user_confidence_scores = get_dummy_user_confidence_scores(user_profiles)
         db_session.add_all(user_confidence_scores)
-
-        app_configs = get_dummy_app_configs()
-        db_session.add_all(app_configs)
 
         # Populate live feedback
         live_feedback = get_dummy_live_feedback_data(session_turns)

--- a/backend/app/data/populate_static_data.py
+++ b/backend/app/data/populate_static_data.py
@@ -5,15 +5,19 @@ from datetime import UTC, datetime
 from sqlmodel import Session as DBSession
 from sqlmodel import col, select
 
-from app.data import create_mock_users, delete_mock_users, get_dummy_user_profiles
+from app.data import (
+    create_mock_users,
+    delete_mock_users,
+    get_dummy_app_configs,
+    get_dummy_user_profiles,
+)
 from app.database import engine
 from app.enums.language import LanguageCode
-from app.models import ConversationCategory, UserProfile
+from app.models import AppConfig, ConversationCategory, UserProfile
 
 base_dir = os.path.dirname(__file__)
 with open(os.path.join(base_dir, 'initial_prompts.json'), encoding='utf-8') as f:
     initial_prompt_data = json.load(f)
-
 
 STATIC_CATEGORIES = [
     ConversationCategory(
@@ -98,14 +102,21 @@ def populate_static_categories() -> None:
         session.commit()
 
 
-def populate_static_personas() -> None:
+def populate_app_config() -> None:
     """
-    Populate the database with static personas.
+    Populate the database with app configs.
     """
-    pass
+    print('Populating app configs...')
+    with DBSession(engine) as session:
+        app_configs = get_dummy_app_configs()
+        for config in app_configs:
+            existing = session.exec(select(AppConfig).where(AppConfig.key == config.key)).first()
+            if not existing:
+                session.add(config)
+        session.commit()
 
 
 if __name__ == '__main__':
-    populate_demo_users()
     populate_static_categories()
-    populate_static_personas()
+    populate_app_config()
+    populate_demo_users()


### PR DESCRIPTION
### Proposed Solution
Update `populate_scatic_data` script, so it can populate the prod and staging deployments with static data and no overlap with `populate_dummy_data`
Overall it populates:
* Categories
* Mock user and mock admin
* App config
Closes #782 
### Testing
Ran `uv run -m app.data.populate_static_data` on local supabase