### PR TITLE
fix(M): remove unnecessary broad except in send-verification and verify-code endpoints

### DIFF
--- a/backend/app/routers/auth_route.py
+++ b/backend/app/routers/auth_route.py
@@ -25,34 +25,22 @@ settings = Settings()
 
 @router.post('/send-verification', response_model=None)
 def send_verification(req: VerificationCodeCreate) -> None:
-    try:
-        verification_status = send_verification_code(req.phone_number)
-        if verification_status == 'pending':
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Failed to send verification code',
-            )
-    except Exception as e:
+    verification_status = send_verification_code(req.phone_number)
+    if verification_status == 'pending':
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        ) from e
+            detail='Failed to send verification code',
+        )
 
 
 @router.post('/verify-code', response_model=None)
 def verify_code(req: VerificationCodeConfirm) -> None:
-    try:
-        verification_status = check_verification_code(req.phone_number, req.code)
-        if verification_status != 'approved':
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail='Invalid verification code',
-            )
-    except Exception as e:
+    verification_status = check_verification_code(req.phone_number, req.code)
+    if verification_status != 'approved':
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
-        ) from e
+            detail='Invalid verification code',
+        )
 
 
 @router.post('', response_model=None, status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
We were using broad except statements that prevented errors from being visible in the logs. If we remove them, the errors will be visible in the logs and FastAPI will automatically return with error code 500 on an error.