### PR TITLE
Session feedback in correct language

### DIFF
--- a/backend/app/services/session_service.py
+++ b/backend/app/services/session_service.py
@@ -388,6 +388,7 @@ class SessionService:
             transcript=transcripts,
             objectives=preparation.objectives,
             key_concepts=key_concepts_str,
+            language_code=conversation_scenario.language_code,
         )
 
         background_tasks.add_task(


### PR DESCRIPTION
### Proposed Solution
The language code wasn't explicitly set in the Feedback request, so this fix assigns it
### Testing
Tested by simulating conversations locally in both English and German
